### PR TITLE
Fix renovate.json matching for vite packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,13 @@
     },
     {
       "groupName": "vite-and-test",
-      "matchPackageNames": ["vite**", "@vite**", "**vite-plugin**"]
+      "matchPackageNames": [
+        "vite*",
+        "@vitejs/**",
+        "@vite-pwa/**",
+        "@vitest/**",
+        "**vite-plugin**"
+      ]
     },
     {
       "groupName": "workbox",


### PR DESCRIPTION
Align with https://docs.renovatebot.com/string-pattern-matching/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Renovate configuration to improve package dependency matching for Vite and related packages.
	- Expanded package rule to include more specific Vite and Vitest package namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->