### PR TITLE
Fix groups in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     },
     {
       "groupName": "dnd-kit",
-      "matchPackageNames": ["@dnd-kit**"]
+      "matchPackageNames": ["@dnd-kit/**"]
     },
     {
       "groupName": "vite-and-test",
@@ -26,19 +26,19 @@
     },
     {
       "groupName": "workbox",
-      "matchPackageNames": ["workbox**"]
+      "matchPackageNames": ["workbox*"]
     },
     {
       "groupName": "prettier",
-      "matchPackageNames": ["prettier**"]
+      "matchPackageNames": ["*prettier*", "pretty-quick"]
     },
     {
       "groupName": "playwright",
-      "matchPackageNames": ["playwright**", "@playwright**"]
+      "matchPackageNames": ["playwright*", "@playwright/**"]
     },
     {
       "groupName": "tailwind",
-      "matchPackageNames": ["**tailwind**", "autoprefixer", "postcss"]
+      "matchPackageNames": ["*tailwind*", "autoprefixer", "postcss"]
     },
     {
       "groupName": "shadcn",


### PR DESCRIPTION
Use matchers correctly according to the renovate configuration.p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Renovate configuration package matching rules
	- Refined package name matching patterns for various dependency groups
	- Improved precision of package dependency updates configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->