### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/martinfrancois/question-driven-talk-assistant/security/code-scanning/2](https://github.com/martinfrancois/question-driven-talk-assistant/security/code-scanning/2)

To correct this issue, you should add a `permissions:` block to your workflow file. The recommended minimal permissions for typical test workflows are `contents: read`, which allows actions to read repository contents but not to write to them. Place this block at the root of the workflow—above the `jobs:` key—so that it applies to all jobs in the workflow unless they declare their own permissions. Edit the file `.github/workflows/test.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block, typically after your workflow `name` and event configuration. No imports or extra definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
