### PR TITLE
test: update tab snapshot after Playwright upgrade

### DIFF
--- a/src/components/questions/__snapshots__/QuestionItem.spec.tsx.snap
+++ b/src/components/questions/__snapshots__/QuestionItem.spec.tsx.snap
@@ -2480,7 +2480,9 @@ exports[`QuestionItem Component with Zustand > Pressing Tab on last non-empty qu
     <div
       aria-live="polite"
       class="sr-only"
-    />
+    >
+      Added a new question below and focused it.
+    </div>
   </div>
   <div
     class="flex items-center space-x-2 p-2 bg-transparent"


### PR DESCRIPTION
## Summary
- fix failing snapshot for Tab key behavior by including live region announcement

## Testing
- `bun run test:unit` *(fails: vitest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f687eb788332b589f2e91df15524