### PR TITLE
Fix Tab addition test for Playwright 1.55

### DIFF
--- a/src/components/questions/QuestionItem.spec.tsx
+++ b/src/components/questions/QuestionItem.spec.tsx
@@ -172,6 +172,9 @@ describe("QuestionItem Component with Zustand", () => {
     const textarea = textareas[2]; // Last question
     textarea.focus();
 
+    // Advance time to generate a unique timestamp for the new question
+    advanceTime();
+
     // Simulate pressing Tab
     const tabEvent = new KeyboardEvent("keydown", {
       key: "Tab",
@@ -179,9 +182,6 @@ describe("QuestionItem Component with Zustand", () => {
       bubbles: true,
     });
     textarea.dispatchEvent(tabEvent);
-
-    // Advance time to generate a unique timestamp for the new question
-    advanceTime();
 
     // Wait for state updates and re-rendering
     await vi.advanceTimersByTimeAsync(100);


### PR DESCRIPTION
## Summary
- run timer advancement before pressing Tab to ensure screen reader messages clear before snapshot

## Testing
- `bun run test:unit` *(fails: vitest: command not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f687eb788332b589f2e91df15524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the keyboard navigation test that verifies adding a new question when pressing Tab on the last non-empty question by refining timer handling.
  * Ensures consistent test execution without altering app behavior, UI, or user workflows.
  * No changes to production code; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->