### PR TITLE
fix: stabilize question tab snapshot

### DIFF
--- a/src/components/questions/QuestionItem.spec.tsx
+++ b/src/components/questions/QuestionItem.spec.tsx
@@ -183,8 +183,9 @@ describe("QuestionItem Component with Zustand", () => {
     // Advance time to generate a unique timestamp for the new question
     advanceTime();
 
-    // Wait for state updates and re-rendering
-    await vi.advanceTimersByTimeAsync(100);
+    // Wait slightly longer than the live region reset timeout to ensure
+    // the announcement has been cleared before taking the snapshot.
+    await vi.advanceTimersByTimeAsync(200);
 
     // Re-fetch the textareas after the update
     const updatedTextareas = container.querySelectorAll("textarea");


### PR DESCRIPTION
## Summary
- ensure screen reader live region resets before snapshot when adding a question with Tab

## Testing
- `bun run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f687eb788332b589f2e91df15524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of keyboard navigation tests related to adding a new question by adjusting wait times so accessibility live region messages clear before snapshotting.
  * Minimizes intermittent CI failures and includes clearer in-test documentation for future maintenance.
  * No impact on production code, UI, or performance; end-user behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->