### PR TITLE
Document headless flag requirement for tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Prettier (with tailwindcss plugin) formats code; a pre-commit hook auto-formats staged files.
 - Unit tests use Vitest and run in a Playwright-provided Chromium browser.
 - End-to-end tests use Playwright.
+- When running tests, include the `--browser.headless` flag to ensure headless execution.
 - Playwright browsers **must** be installed before running any tests (including unit tests):
   ```bash
   bun x playwright install --with-deps
@@ -36,7 +37,7 @@
 3. Type check: `bun x tsc -p tsconfig.json --noEmit`.
 4. Build: `bun run build`.
 5. Install Playwright browsers (required even for unit tests): `bun x playwright install --with-deps`.
-6. Run unit tests: `bun run test:unit`.
+6. Run unit tests: `bun run test:unit -- --browser.headless`.
 7. For end-to-end tests:
    - Start preview server: `bun run preview -- --port 5173`.
    - In another terminal, run: `bun run test:e2e`.


### PR DESCRIPTION
## Summary
- note that tests should run with `--browser.headless`
- include the flag in the unit test command in the development workflow

## Testing
- `bun install`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56ea8846483329ab6c51008b16ac3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to run tests in headless mode using the browser headless flag for consistency across environments.
  * Updated unit test command examples to include the headless flag, aligning the development workflow with recommended testing practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->