### PR TITLE
Add fast-check property tests for save utilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",
+        "fast-check": "3.16.0",
         "globals": "16.4.0",
         "playwright": "1.51.1",
         "postcss": "8.5.6",
@@ -871,6 +872,8 @@
 
     "expect-type": ["expect-type@1.2.1", "", {}, "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw=="],
 
+    "fast-check": ["fast-check@3.16.0", "", { "dependencies": { "pure-rand": "^6.0.0" } }, "sha512-k8GtQHi4pJoRQ1gVDFQno+/FVkowo/ehiz/aCj9O/D7HRWb1sSFzNrw+iPVU8QlWtH+jNwbuN+dDVg3QkS56DQ=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -1234,6 +1237,8 @@
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
     "@types/wicg-file-system-access": "2023.10.6",
+    "fast-check": "3.16.0",
     "@typescript-eslint/eslint-plugin": "8.43.0",
     "@typescript-eslint/parser": "8.43.0",
     "@vite-pwa/assets-generator": "1.0.1",

--- a/src/save-questions.fast-check.spec.ts
+++ b/src/save-questions.fast-check.spec.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from "vitest";
+import fc from "fast-check";
+import { format } from "date-fns";
+import {
+  generateFileName,
+  generateMarkdownContent,
+  saveFile,
+} from "./save-questions.ts";
+import type { Question } from "./stores";
+
+interface WindowWithPicker extends Window {
+  showSaveFilePicker?: () => Promise<{
+    createWritable: () => Promise<{
+      write: (data: string) => Promise<void>;
+      close: () => Promise<void>;
+    }>;
+  }>;
+}
+
+const win = window as WindowWithPicker;
+
+/**
+ * Property-based tests for save-questions utilities.
+ *
+ * These tests leverage fast-check to fuzz a wide range of inputs and ensure
+ * that our save helpers behave correctly for any arbitrary data.
+ */
+
+describe("save-questions fast-check", () => {
+  describe("generateFileName", () => {
+    it("sanitises arbitrary titles into safe file names", () => {
+      fc.assert(
+        fc.property(fc.string(), fc.date(), (title, date) => {
+          const expectedTitle = title
+            .toLowerCase()
+            .replace(/[^a-z0-9- ]+/g, "")
+            .replace(/\s+/g, "-")
+            .replace(/^-+/, "")
+            .replace(/-+$/, "");
+          const fileDate = format(date, "yyyy-MM-dd");
+          const result = generateFileName(title, date);
+          expect(result).toBe(`${fileDate}_${expectedTitle}_questions.md`);
+          expect(result).toMatch(
+            /^\d{4}-\d{2}-\d{2}_[a-z0-9-]*_questions\.md$/,
+          );
+          expect(result.includes("--")).toBe(false);
+        }),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  describe("generateMarkdownContent", () => {
+    const questionArb = fc.record({
+      id: fc.string(),
+      text: fc.string(),
+      answered: fc.boolean(),
+      highlighted: fc.boolean(),
+    });
+
+    it("includes every question with the correct checkbox", () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.string(),
+          fc.date(),
+          fc.array(questionArb, { maxLength: 5 }),
+          (title, footer, date, questions) => {
+            const result = generateMarkdownContent(
+              title,
+              footer,
+              date,
+              questions as Question[],
+            );
+            const formattedDate = format(date, "do 'of' MMMM yyyy");
+            expect(
+              result.startsWith(
+                `# ${title}\n\n${footer}\n\n${formattedDate}\n\n`,
+              ),
+            ).toBe(true);
+            for (const q of questions) {
+              const firstLine = (q.text || "").split("\n")[0];
+              const checkbox = q.answered ? "[x]" : "[ ]";
+              expect(result).toContain(`- ${checkbox} ${firstLine}`);
+            }
+          },
+        ),
+        { numRuns: 50 },
+      );
+    });
+
+    const multiLineQuestions = fc
+      .array(questionArb, { maxLength: 3 })
+      .chain((qs) =>
+        fc
+          .record({
+            id: fc.string(),
+            text: fc
+              .tuple(fc.string(), fc.string())
+              .map(([a, b]) => `${a}\n${b}`),
+            answered: fc.boolean(),
+            highlighted: fc.boolean(),
+          })
+          .map((ml) => [...qs, ml]),
+      );
+
+    it("indents continuation lines for multi-line questions", () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.string(),
+          fc.date(),
+          multiLineQuestions,
+          (title, footer, date, questions) => {
+            const result = generateMarkdownContent(
+              title,
+              footer,
+              date,
+              questions as Question[],
+            );
+            for (const q of questions) {
+              if (q.text.includes("\n")) {
+                const [first, ...rest] = q.text.split("\n");
+                const checkbox = q.answered ? "[x]" : "[ ]";
+                const expected = [
+                  `- ${checkbox} ${first}`,
+                  ...rest.map((line) => `      ${line}`),
+                ].join("\n");
+                expect(result).toContain(expected);
+              }
+            }
+          },
+        ),
+        { numRuns: 20 },
+      );
+    });
+
+    it("handles empty question text", () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.string(),
+          fc.date(),
+          fc.boolean(),
+          fc.array(questionArb, { maxLength: 3 }),
+          (title, footer, date, answered, questions) => {
+            const withEmpty = [
+              ...questions,
+              { id: "empty", text: "", answered, highlighted: false },
+            ];
+            const result = generateMarkdownContent(
+              title,
+              footer,
+              date,
+              withEmpty as Question[],
+            );
+            const checkbox = answered ? "[x]" : "[ ]";
+            expect(result).toContain(`- ${checkbox}`);
+          },
+        ),
+        { numRuns: 20 },
+      );
+    });
+  });
+
+  describe("saveFile", () => {
+    it("uses the File System Access API when available", async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string(),
+          fc.string(),
+          async (fileName, content) => {
+            vi.restoreAllMocks();
+            const write = vi.fn();
+            const close = vi.fn();
+            const createWritable = vi.fn().mockResolvedValue({ write, close });
+            win.showSaveFilePicker = vi
+              .fn()
+              .mockResolvedValue({ createWritable });
+            await saveFile(fileName, content);
+            expect(win.showSaveFilePicker).toHaveBeenCalled();
+            expect(createWritable).toHaveBeenCalled();
+            expect(write).toHaveBeenCalledWith(content);
+            expect(close).toHaveBeenCalled();
+          },
+        ),
+        { numRuns: 10 },
+      );
+    });
+
+    it("falls back to anchor download when API is missing", async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string(),
+          fc.string(),
+          async (fileName, content) => {
+            vi.restoreAllMocks();
+            delete win.showSaveFilePicker;
+            const click = vi.fn();
+            const anchor = {
+              href: "",
+              download: "",
+              click,
+            } as unknown as HTMLAnchorElement;
+            vi.spyOn(document, "createElement").mockReturnValue(anchor);
+            const appendSpy = vi.spyOn(document.body, "appendChild");
+            const removeSpy = vi.spyOn(document.body, "removeChild");
+            const createUrlSpy = vi
+              .spyOn(URL, "createObjectURL")
+              .mockReturnValue("blob:1");
+            const revokeUrlSpy = vi.spyOn(URL, "revokeObjectURL");
+            await saveFile(fileName, content);
+            expect(anchor.download).toBe(fileName);
+            expect(click).toHaveBeenCalled();
+            expect(appendSpy).toHaveBeenCalledWith(anchor);
+            expect(removeSpy).toHaveBeenCalledWith(anchor);
+            expect(createUrlSpy).toHaveBeenCalled();
+            expect(revokeUrlSpy).toHaveBeenCalled();
+          },
+        ),
+        { numRuns: 10 },
+      );
+    });
+
+    it("logs errors thrown during save", async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string(),
+          fc.string(),
+          async (fileName, content) => {
+            vi.restoreAllMocks();
+            const error = new Error("boom");
+            win.showSaveFilePicker = vi.fn().mockRejectedValue(error);
+            const errSpy = vi
+              .spyOn(console, "error")
+              .mockImplementation(() => undefined);
+            await saveFile(fileName, content);
+            expect(errSpy).toHaveBeenCalledWith("Error saving file:", error);
+          },
+        ),
+        { numRuns: 5 },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `fast-check` as a development dependency
- introduce comprehensive property-based and fuzz tests for question saving utilities

## Testing
- `bun run lint`
- `bun x tsc -p tsconfig.json --noEmit`
- `bun run build`
- `bun x playwright install --with-deps` *(failed: long install caused environment issues)*
- `bun run test:unit` *(failed: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c56c8667a083329c1c95125cd39a38