### PR TITLE
Fix inherited lint and flaky time-format test

### DIFF
--- a/e2e/MainLayout.spec.ts
+++ b/e2e/MainLayout.spec.ts
@@ -77,15 +77,13 @@ test.describe("MainLayout e2e tests", () => {
 
   test("should toggle time format in TimeDisplay", async () => {
     // given
-    const initialFormat = await mainLayoutPage.timeDisplay.getAttribute(
-      "data-time-format",
-    );
+    const initialFormat =
+      await mainLayoutPage.timeDisplay.getAttribute("data-time-format");
 
     // when
     await mainLayoutPage.toggleTimeFormat();
-    const toggledFormat = await mainLayoutPage.timeDisplay.getAttribute(
-      "data-time-format",
-    );
+    const toggledFormat =
+      await mainLayoutPage.timeDisplay.getAttribute("data-time-format");
 
     // then
     expect(toggledFormat).not.toEqual(initialFormat);

--- a/e2e/MainLayout.spec.ts
+++ b/e2e/MainLayout.spec.ts
@@ -77,15 +77,18 @@ test.describe("MainLayout e2e tests", () => {
 
   test("should toggle time format in TimeDisplay", async () => {
     // given
-    const initialTime = await mainLayoutPage.timeDisplay.textContent();
+    const initialFormat = await mainLayoutPage.timeDisplay.getAttribute(
+      "data-time-format",
+    );
 
     // when
     await mainLayoutPage.toggleTimeFormat();
-    const toggledTime = await mainLayoutPage.timeDisplay.textContent();
+    const toggledFormat = await mainLayoutPage.timeDisplay.getAttribute(
+      "data-time-format",
+    );
 
     // then
-    // TODO potentially flaky, if toggled right before minute advances
-    expect(toggledTime).not.toEqual(initialTime);
+    expect(toggledFormat).not.toEqual(initialFormat);
   });
 
   test("should not open fullscreen QR code when URL is empty", async () => {

--- a/src/components/layout/TimeDisplay.tsx
+++ b/src/components/layout/TimeDisplay.tsx
@@ -36,6 +36,7 @@ const TimeDisplay: FC = () => {
       onClick={toggleTimeFormat}
       className="cursor-pointer pr-2 text-right text-sm opacity-70 hover:opacity-100"
       data-testid="time-display"
+      data-time-format={timeFormat24h ? "24h" : "12h"}
       aria-label={"Time: " + time}
     >
       {time}

--- a/src/components/questions/QuestionItem.tsx
+++ b/src/components/questions/QuestionItem.tsx
@@ -232,8 +232,7 @@ const QuestionItem: FC<QuestionItemProps> = ({
       e.preventDefault();
       if (
         question.text.trim() !== "" &&
-        (!questions[currentIndex + 1] ||
-          questions[currentIndex + 1].text.trim() !== "")
+        questions[currentIndex + 1]?.text.trim() !== ""
       ) {
         const newQuestion = createEmptyQuestion();
         insertQuestion(currentIndex + 1, newQuestion);


### PR DESCRIPTION
## Summary

- rewrite the question insertion guard with equivalent optional chaining so current lint passes
- expose the active time format as test state
- assert the format transition directly instead of comparing clock text across a minute boundary

## Verification

I ran the complete CI-equivalent workflow locally in the pinned Playwright container using Bun 1.3.14:

- `bun run lint`
- `bun x tsc -p tsconfig.json --noEmit`
- `bun run build`
- `bun run test:unit -- --browser.headless`
- `CI=true bun run test:e2e` — 46 passed

Codex reviewed the complete uncommitted diff and reported no actionable findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling when adding questions with the Enter key.
  * Improved test reliability for switching between 12-hour and 24-hour time formats.

* **Enhancements**
  * Added an attribute to the time display button indicating the active time format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->