### PR TITLE
test: measure coverage honestly and raise it to 90%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Install Playwright Browsers
         run: bun x playwright install --with-deps
-      - name: Unit & Component Tests
+      # Fails the build when line coverage over src/** drops below the
+      # threshold configured in vitest.config.ts.
+      - name: Unit & Component Tests (enforces 80% line coverage)
         run: bun run test:unit
       # Start the frontend server in the background
       - name: Start frontend server

--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,7 @@ Temporary Items
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Failure screenshots written by the vitest browser runner. These are uploaded
+# as CI artifacts, never committed (committed snapshots live in __snapshots__).
+__screenshots__/

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import screenfull from "screenfull";
+import App from "./App.tsx";
+import {
+  StorageName,
+  useCompleteTour,
+  useFontSize,
+  useSetFooter,
+  useSetQuestions,
+  useSetTitle,
+} from "./stores";
+import { pressKey } from "./test-utils/keyboard.ts";
+import { interact } from "./test-utils/react.ts";
+
+interface RecordedWrite {
+  fileName: string | undefined;
+  content: string;
+}
+
+/**
+ * Integration coverage for the application shell. The whole real component tree
+ * is mounted: the real zustand stores, the real `react-hotkeys-hook` bindings,
+ * the real Radix dialogs, the real `qrcode.react` and dnd-kit powered content,
+ * the real `virtual:pwa-register/react` hook and the real `react-joyride` tour.
+ *
+ * Two host capabilities are intercepted because a headless test cannot supply
+ * them: the File System Access save picker (a native chooser) and screenfull's
+ * fullscreen transition (which the browser only grants after a user gesture).
+ * Both are still asserted against their real API surface.
+ */
+describe("App", () => {
+  let writes: RecordedWrite[] = [];
+
+  // `@types/wicg-file-system-access` declares `showSaveFilePicker` as always
+  // present; this view of `window` makes it optional so the test can install
+  // and remove its own implementation.
+  interface OptionalPicker {
+    showSaveFilePicker?: typeof window.showSaveFilePicker;
+  }
+  const testWindow: OptionalPicker = window;
+
+  beforeEach(() => {
+    writes = [];
+    for (const name of Object.values(StorageName)) {
+      localStorage.removeItem(name);
+    }
+    vi.stubGlobal("prompt", () => null);
+    testWindow.showSaveFilePicker = (options?: SaveFilePickerOptions) => {
+      let content = "";
+      return Promise.resolve({
+        createWritable: () =>
+          Promise.resolve({
+            write: (data: string) => {
+              content += data;
+              return Promise.resolve();
+            },
+            close: () => {
+              writes.push({ fileName: options?.suggestedName, content });
+              return Promise.resolve();
+            },
+          }),
+      } as unknown as FileSystemFileHandle);
+    };
+  });
+
+  afterEach(() => {
+    delete testWindow.showSaveFilePicker;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const shell = (container: HTMLElement): HTMLElement => {
+    const el = container.firstElementChild as HTMLElement | null;
+    if (!el) throw new Error("app shell not rendered");
+    return el;
+  };
+
+  const fontSizeHook = () => renderHook(() => useFontSize());
+
+  /**
+   * Renders the app with the guided tour already completed, so the joyride
+   * overlay does not sit on top of the UI the assertions look at.
+   */
+  const renderApp = async () => {
+    const setup = renderHook(() => ({
+      completeTour: useCompleteTour(),
+      setTitle: useSetTitle(),
+      setFooter: useSetFooter(),
+      setQuestions: useSetQuestions(),
+    }));
+    act(() => {
+      setup.result.current.completeTour();
+    });
+    return render(<App />);
+  };
+
+  it("renders the whole application shell", async () => {
+    const { container } = await renderApp();
+
+    expect(
+      container.querySelector("[data-testid='main-layout-container']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("[data-testid='main-header']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("[data-testid='main-footer']"),
+    ).not.toBeNull();
+    expect(container.querySelector("[data-testid='qr-code']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='help-icon']")).not.toBeNull();
+    expect(container.querySelector("textarea")).not.toBeNull();
+  });
+
+  it("applies the current font size to the shell", async () => {
+    const { container } = await renderApp();
+    const font = fontSizeHook();
+
+    expect(shell(container).style.fontSize).toBe(
+      `${String(font.result.current)}px`,
+    );
+  });
+
+  it("grows the font size on ctrl+p", async () => {
+    const { container } = await renderApp();
+    const before = Number.parseInt(shell(container).style.fontSize, 10);
+
+    await interact(() => {
+      pressKey({ key: "p", code: "KeyP", ctrl: true });
+    });
+
+    expect(Number.parseInt(shell(container).style.fontSize, 10)).toBe(
+      before + 2,
+    );
+  });
+
+  it("shrinks the font size on ctrl+m", async () => {
+    const { container } = await renderApp();
+    const before = Number.parseInt(shell(container).style.fontSize, 10);
+
+    await interact(() => {
+      pressKey({ key: "m", code: "KeyM", ctrl: true });
+    });
+
+    expect(Number.parseInt(shell(container).style.fontSize, 10)).toBe(
+      before - 2,
+    );
+  });
+
+  it("toggles the dark mode class on ctrl+d", async () => {
+    const { container } = await renderApp();
+    const initial = shell(container).classList.contains("dark");
+
+    await interact(() => {
+      pressKey({ key: "d", code: "KeyD", ctrl: true });
+    });
+    expect(shell(container).classList.contains("dark")).toBe(!initial);
+
+    await interact(() => {
+      pressKey({ key: "d", code: "KeyD", ctrl: true });
+    });
+    expect(shell(container).classList.contains("dark")).toBe(initial);
+    expect(shell(container).classList.contains("light")).toBe(true);
+  });
+
+  it("saves the questions as markdown on ctrl+s", async () => {
+    const setup = renderHook(() => ({
+      completeTour: useCompleteTour(),
+      setTitle: useSetTitle(),
+      setFooter: useSetFooter(),
+      setQuestions: useSetQuestions(),
+    }));
+    act(() => {
+      setup.result.current.completeTour();
+      setup.result.current.setTitle("My Talk!");
+      setup.result.current.setFooter("Some Footer");
+      setup.result.current.setQuestions([
+        {
+          id: "1",
+          text: "First question?",
+          answered: true,
+          highlighted: false,
+        },
+        {
+          id: "2",
+          text: "Second question?",
+          answered: false,
+          highlighted: false,
+        },
+      ]);
+    });
+    await render(<App />);
+
+    await interact(() => {
+      pressKey({ key: "s", code: "KeyS", ctrl: true });
+    });
+    await vi.waitFor(() => {
+      if (writes.length === 0) throw new Error("no file written yet");
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].fileName).toMatch(
+      /^\d{4}-\d{2}-\d{2}_my-talk_questions\.md$/,
+    );
+    expect(writes[0].content).toContain("# My Talk!\n\nSome Footer\n\n");
+    expect(writes[0].content).toContain("- [x] First question?\n");
+    expect(writes[0].content).toContain("- [ ] Second question?\n");
+  });
+
+  it("runs in a browser where screenfull reports fullscreen support", () => {
+    expect(screenfull.isEnabled).toBe(true);
+  });
+
+  it("asks screenfull to enter and leave fullscreen on ctrl+f", async () => {
+    const request = vi
+      .spyOn(screenfull, "request")
+      .mockResolvedValue(undefined);
+    const exit = vi.spyOn(screenfull, "exit").mockResolvedValue(undefined);
+    await renderApp();
+
+    await interact(() => {
+      pressKey({ key: "f", code: "KeyF", ctrl: true });
+    });
+    await vi.waitFor(() => {
+      if (request.mock.calls.length === 0) {
+        throw new Error("fullscreen not requested yet");
+      }
+    });
+    expect(exit).not.toHaveBeenCalled();
+
+    await interact(() => {
+      pressKey({ key: "f", code: "KeyF", ctrl: true });
+    });
+    await vi.waitFor(() => {
+      if (exit.mock.calls.length === 0) {
+        throw new Error("fullscreen not exited yet");
+      }
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses the browser's own find-in-page binding for ctrl+f", async () => {
+    vi.spyOn(screenfull, "request").mockResolvedValue(undefined);
+    await renderApp();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "f",
+      code: "KeyF",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    await interact(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves unrelated keystrokes alone", async () => {
+    const { container } = await renderApp();
+    const before = shell(container).style.fontSize;
+
+    const event = new KeyboardEvent("keydown", {
+      key: "g",
+      code: "KeyG",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    await interact(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(shell(container).style.fontSize).toBe(before);
+  });
+
+  it("opens the help modal from the app shell via ctrl+h", async () => {
+    await renderApp();
+
+    await interact(() => {
+      pressKey({ key: "h", code: "KeyH", ctrl: true });
+    });
+
+    expect(
+      document.body.querySelector("[data-testid='help-modal']"),
+    ).not.toBeNull();
+  });
+
+  // Kept last: unmounting tears down the shared render root that the
+  // `renderHook` helpers in the other tests rely on.
+  it("stops listening for ctrl+f once unmounted", async () => {
+    const request = vi
+      .spyOn(screenfull, "request")
+      .mockResolvedValue(undefined);
+    const rendered = await renderApp();
+
+    await rendered.unmount();
+    await interact(() => {
+      pressKey({ key: "f", code: "KeyF", ctrl: true, target: window });
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/src/PWABadge.spec.tsx
+++ b/src/PWABadge.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { useRegisterSW } from "virtual:pwa-register/react";
+import { renderHook } from "@testing-library/react";
+import PWABadge from "./PWABadge.tsx";
+
+/**
+ * Exercises the real `virtual:pwa-register/react` module that vite-plugin-pwa
+ * injects into the build. If the plugin stops providing the virtual module, or
+ * changes the shape of the hook's return value, these tests fail at import or
+ * at the destructuring in the component rather than passing against a stub.
+ */
+describe("PWABadge", () => {
+  it("resolves the virtual pwa-register module provided by vite-plugin-pwa", () => {
+    expect(typeof useRegisterSW).toBe("function");
+  });
+
+  it("returns the needRefresh tuple and the update function the badge relies on", () => {
+    const { result } = renderHook(() => useRegisterSW({}));
+
+    expect(Array.isArray(result.current.needRefresh)).toBe(true);
+    expect(result.current.needRefresh).toHaveLength(2);
+    expect(typeof result.current.needRefresh[0]).toBe("boolean");
+    expect(typeof result.current.needRefresh[1]).toBe("function");
+    expect(typeof result.current.updateServiceWorker).toBe("function");
+  });
+
+  it("renders nothing while no service worker update is waiting", async () => {
+    const { container } = await render(<PWABadge />);
+
+    expect(container.innerHTML).toBe("");
+    expect(document.body.querySelector("[role='alert']")).toBeNull();
+  });
+
+  it("mounts and unmounts without registering a periodic sync interval", async () => {
+    // The component hard-codes `period = 0`, which disables periodic sync.
+    const before = window.setTimeout(() => undefined, 0);
+    window.clearTimeout(before);
+
+    const rendered = await render(<PWABadge />);
+    await rendered.unmount();
+
+    expect(document.body.querySelector("[role='alert']")).toBeNull();
+  });
+});

--- a/src/components/help/Help.spec.tsx
+++ b/src/components/help/Help.spec.tsx
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import { Help } from "./Help.tsx";
+import { StorageName, useCompleteTour, useTourCompleted } from "@/stores";
+import { pressKey } from "@/test-utils/keyboard.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Drives the real help surface: the real `react-hotkeys-hook` binding, the real
+ * Radix dialog primitive (which portals into `document.body`), the real
+ * `react-focus-lock` wrapper, the real `virtual:pwa-register/react` hook from
+ * vite-plugin-pwa, and the real zustand onboarding store. Nothing is mocked.
+ */
+describe("Help", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.ONBOARDING);
+  });
+
+  const tourHook = () =>
+    renderHook(() => ({
+      tourCompleted: useTourCompleted(),
+      completeTour: useCompleteTour(),
+    }));
+
+  const modal = (): HTMLElement | null =>
+    document.body.querySelector("[data-testid='help-modal']");
+
+  const helpIcon = (container: HTMLElement): HTMLElement => {
+    const el = container.querySelector<HTMLElement>(
+      "[data-testid='help-icon']",
+    );
+    if (!el) throw new Error("help icon not rendered");
+    return el;
+  };
+
+  const openViaIcon = async (container: HTMLElement) => {
+    await interact(() => helpIcon(container).click());
+  };
+
+  it("renders a labelled help button and no modal at first", async () => {
+    const { container } = await render(<Help />);
+
+    expect(helpIcon(container).getAttribute("aria-label")).toBe("Open help");
+    expect(helpIcon(container).querySelector("svg")).not.toBeNull();
+    expect(modal()).toBeNull();
+  });
+
+  it("opens the modal when the help button is clicked", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    expect(modal()).not.toBeNull();
+    expect(modal()?.textContent).toContain("Help");
+  });
+
+  it("opens the modal via the ctrl+h hotkey", async () => {
+    await render(<Help />);
+
+    await interact(() => {
+      pressKey({ key: "h", code: "KeyH", ctrl: true });
+    });
+
+    expect(modal()).not.toBeNull();
+  });
+
+  it("lists the application shortcuts in a table with a caption", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    const table = modal()?.querySelector("table");
+    expect(table).not.toBeNull();
+    expect(table?.querySelector("caption")?.textContent).toBe(
+      "Keyboard Shortcuts and Descriptions",
+    );
+    const headers = Array.from(table?.querySelectorAll("thead th") ?? []).map(
+      (th) => th.textContent,
+    );
+    expect(headers).toEqual(["Shortcut", "Description"]);
+  });
+
+  it("documents every section of shortcuts", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    const sectionHeadings = Array.from(
+      modal()?.querySelectorAll("tbody th[colspan='2']") ?? [],
+    ).map((th) => th.textContent);
+
+    expect(sectionHeadings).toEqual([
+      "Features",
+      "Managing Questions",
+      "Reordering Questions",
+      "Navigation",
+      "Highlighting & Answering",
+    ]);
+  });
+
+  it("documents the shortcuts the application actually binds", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+    const text = modal()?.textContent ?? "";
+
+    expect(text).toContain("Increase font size");
+    expect(text).toContain("Decrease font size");
+    expect(text).toContain("Toggle dark mode");
+    expect(text).toContain("Show a large QR code on the screen");
+    expect(text).toContain("Enter full-screen mode");
+    expect(text).toContain("Save questions to a Markdown file");
+    expect(text).toContain("Show help (this pop-up window)");
+    expect(text).toContain("Edit title text");
+    expect(text).toContain("Edit footer text");
+    expect(text).toContain("Edit QR code URL");
+    expect(text).toContain("Clear all questions (with confirmation)");
+    expect(text).toContain("Move the current question up");
+    expect(text).toContain("Move the current question down");
+    expect(text).toContain("Mark question as answered");
+  });
+
+  it("renders the shortcut keys as kbd elements", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    const keys = Array.from(modal()?.querySelectorAll("kbd") ?? []).map(
+      (kbd) => kbd.textContent,
+    );
+    expect(keys.length).toBeGreaterThan(10);
+    expect(keys).toContain("Ctrl");
+    expect(keys).toContain("Shift");
+    expect(keys).toContain("Backspace");
+  });
+
+  it("links to the author and the source repository, safely", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    const links = Array.from(modal()?.querySelectorAll("a") ?? []);
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://www.fmartin.ch");
+    expect(hrefs).toContain(
+      "https://github.com/martinfrancois/question-driven-talk-assistant",
+    );
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
+
+  it("hides the update button while no service worker update is pending", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    expect(modal()?.textContent).not.toContain("New version available");
+    expect(modal()?.textContent).not.toContain("Update to the latest version");
+  });
+
+  it("restarts the guided tour and closes the modal", async () => {
+    const tour = tourHook();
+    act(() => {
+      tour.result.current.completeTour();
+    });
+    expect(tour.result.current.tourCompleted).toBe(true);
+
+    const { container } = await render(<Help />);
+    await openViaIcon(container);
+
+    const restart = modal()?.querySelector<HTMLElement>(
+      "[data-testid='restart-tour']",
+    );
+    expect(restart).not.toBeNull();
+    await interact(() => restart?.click());
+
+    expect(tour.result.current.tourCompleted).toBe(false);
+    expect(modal()).toBeNull();
+  });
+
+  it("closes when the dialog close button is used", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+    const close = document.body.querySelector<HTMLElement>(
+      "[data-testid='modal-close']",
+    );
+    await interact(() => close?.click());
+
+    expect(modal()).toBeNull();
+  });
+
+  it("can be reopened after closing", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+    await interact(() =>
+      document.body
+        .querySelector<HTMLElement>("[data-testid='modal-close']")
+        ?.click(),
+    );
+    await openViaIcon(container);
+
+    expect(modal()).not.toBeNull();
+  });
+
+  it("moves focus into the dialog when it opens", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    expect(modal()?.contains(document.activeElement)).toBe(true);
+  });
+
+  it("describes itself for assistive technology", async () => {
+    const { container } = await render(<Help />);
+
+    await openViaIcon(container);
+
+    const description = modal()?.querySelector(".sr-only");
+    expect(description?.textContent).toContain(
+      "Help dialog containing information about shortcuts, features,",
+    );
+    expect(description?.textContent).toContain(
+      "and a button to restart the guided tour.",
+    );
+  });
+});

--- a/src/components/hooks/dark-mode-classnames.spec.ts
+++ b/src/components/hooks/dark-mode-classnames.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDarkModeClassName } from "./dark-mode-classnames.ts";
+import { StorageName, useDarkMode, useToggleDarkMode } from "@/stores";
+
+/**
+ * Drives the real hook against the real preferences store; nothing is stubbed.
+ */
+describe("useDarkModeClassName", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.PREFERENCES);
+  });
+
+  const renderDarkMode = () => {
+    const rendered = renderHook(() => ({
+      className: useDarkModeClassName(),
+      darkMode: useDarkMode(),
+      toggleDarkMode: useToggleDarkMode(),
+    }));
+    // The store is shared across this file, so start from a known light state.
+    if (rendered.result.current.darkMode) {
+      act(() => {
+        rendered.result.current.toggleDarkMode();
+      });
+    }
+    return rendered;
+  };
+
+  it("returns 'light' while dark mode is off", () => {
+    const { result } = renderDarkMode();
+
+    expect(result.current.className).toBe("light");
+  });
+
+  it("returns 'dark' once dark mode is switched on", () => {
+    const { result } = renderDarkMode();
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.className).toBe("dark");
+  });
+
+  it("returns to 'light' when dark mode is switched off again", () => {
+    const { result } = renderDarkMode();
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.className).toBe("light");
+  });
+});

--- a/src/components/layout/Footer.spec.tsx
+++ b/src/components/layout/Footer.spec.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { Footer } from "./Footer.tsx";
+import { StorageName } from "@/stores";
+import { pressKey } from "@/test-utils/keyboard.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Renders the real `Footer` against the real zustand layout store and the real
+ * `react-hotkeys-hook`. Only `window.prompt` is stubbed, because a native
+ * browser dialog cannot run unattended.
+ */
+describe("Footer", () => {
+  let promptCalls: (string | undefined)[] = [];
+  let promptAnswer: string | null = null;
+
+  beforeEach(() => {
+    promptCalls = [];
+    promptAnswer = null;
+    localStorage.removeItem(StorageName.LAYOUT);
+    vi.stubGlobal("prompt", (message?: string) => {
+      promptCalls.push(message);
+      return promptAnswer;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const footer = (container: HTMLElement): HTMLElement => {
+    const el = container.querySelector<HTMLElement>(
+      "[data-testid='main-footer']",
+    );
+    if (!el) throw new Error("footer not rendered");
+    return el;
+  };
+
+  /**
+   * The layout store is shared by every test in this file, so drive it to a
+   * known footer through the component's own edit flow first.
+   */
+  const renderWithFooter = async (text: string): Promise<HTMLElement> => {
+    const { container } = await render(<Footer />);
+    promptAnswer = text;
+    await interact(() => footer(container).click());
+    promptCalls = [];
+    promptAnswer = null;
+    return container;
+  };
+
+  it("renders the footer held in the store", async () => {
+    const container = await renderWithFooter("François Martin");
+
+    expect(footer(container).textContent).toBe("François Martin");
+  });
+
+  it("writes the prompt answer back into the store", async () => {
+    const container = await renderWithFooter("Old footer");
+
+    promptAnswer = "New footer";
+    await interact(() => footer(container).click());
+
+    expect(promptCalls).toEqual(["Edit Footer"]);
+    expect(footer(container).textContent).toBe("New footer");
+  });
+
+  it("keeps the footer when the prompt is cancelled", async () => {
+    const container = await renderWithFooter("Unchanged");
+
+    promptAnswer = null;
+    await interact(() => footer(container).click());
+
+    expect(footer(container).textContent).toBe("Unchanged");
+  });
+
+  it("opens the footer prompt via the ctrl+shift+f hotkey", async () => {
+    const container = await renderWithFooter("Before hotkey");
+
+    promptAnswer = "After hotkey";
+    await interact(() => {
+      pressKey({ key: "F", code: "KeyF", ctrl: true, shift: true });
+    });
+
+    expect(promptCalls).toEqual(["Edit Footer"]);
+    expect(footer(container).textContent).toBe("After hotkey");
+  });
+
+  it("ignores the hotkey when the ctrl modifier is missing", async () => {
+    await renderWithFooter("Untouched");
+
+    await interact(() => {
+      pressKey({ key: "F", code: "KeyF", shift: true });
+    });
+
+    expect(promptCalls).toEqual([]);
+  });
+
+  it("describes a filled footer for assistive technology", async () => {
+    const container = await renderWithFooter("My footer");
+
+    expect(footer(container).getAttribute("aria-label")).toBe(
+      "Footer text: My footer. Click to edit footer.",
+    );
+  });
+
+  it("describes a whitespace-only footer as empty for assistive technology", async () => {
+    const container = await renderWithFooter("  ");
+
+    expect(footer(container).getAttribute("aria-label")).toBe(
+      "Empty footer. Click to add footer.",
+    );
+  });
+
+  it("announces its keyboard shortcut", async () => {
+    const container = await renderWithFooter("Shortcut");
+
+    expect(footer(container).getAttribute("aria-keyshortcuts")).toBe(
+      "Control+Shift+F to edit footer text",
+    );
+  });
+});

--- a/src/components/layout/Header.spec.tsx
+++ b/src/components/layout/Header.spec.tsx
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { act } from "@testing-library/react";
+import { Header } from "./Header.tsx";
+import { StorageName } from "@/stores";
+import { pressKey } from "@/test-utils/keyboard.ts";
+
+/**
+ * Renders the real `Header` against the real zustand layout store and the real
+ * `react-hotkeys-hook`. The only stub is `window.prompt`, a browser dialog that
+ * cannot run unattended; every library the component integrates with runs for
+ * real.
+ */
+describe("Header", () => {
+  let promptCalls: (string | undefined)[] = [];
+  let promptAnswer: string | null = null;
+
+  beforeEach(() => {
+    promptCalls = [];
+    promptAnswer = null;
+    localStorage.removeItem(StorageName.LAYOUT);
+    vi.stubGlobal("prompt", (message?: string) => {
+      promptCalls.push(message);
+      return promptAnswer;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const heading = (container: HTMLElement): HTMLHeadingElement => {
+    const el = container.querySelector<HTMLHeadingElement>(
+      "[data-testid='main-header']",
+    );
+    if (!el) throw new Error("header not rendered");
+    return el;
+  };
+
+  const clickHeading = async (container: HTMLElement): Promise<void> => {
+    await act(async () => {
+      heading(container).click();
+      await Promise.resolve();
+    });
+  };
+
+  /**
+   * The layout store is shared by every test in this file, so drive it to a
+   * known title through the component's own edit flow first.
+   */
+  const renderWithTitle = async (title: string): Promise<HTMLElement> => {
+    const { container } = await render(<Header />);
+    promptAnswer = title;
+    await clickHeading(container);
+    promptCalls = [];
+    promptAnswer = null;
+    return container;
+  };
+
+  it("renders the title held in the store", async () => {
+    const container = await renderWithTitle("Ask me anything");
+
+    expect(heading(container).textContent).toBe("Ask me anything");
+  });
+
+  it("writes the prompt answer back into the store", async () => {
+    const container = await renderWithTitle("Old title");
+
+    promptAnswer = "New title";
+    await clickHeading(container);
+
+    expect(promptCalls).toEqual(["Edit Title"]);
+    expect(heading(container).textContent).toBe("New title");
+  });
+
+  it("keeps the title when the prompt is cancelled", async () => {
+    const container = await renderWithTitle("Unchanged");
+
+    promptAnswer = null;
+    await clickHeading(container);
+
+    expect(promptCalls).toEqual(["Edit Title"]);
+    expect(heading(container).textContent).toBe("Unchanged");
+  });
+
+  it("accepts an empty title from the prompt", async () => {
+    const container = await renderWithTitle("Something");
+
+    promptAnswer = "";
+    await clickHeading(container);
+
+    expect(heading(container).textContent).toBe("");
+  });
+
+  it("opens the title prompt via the ctrl+shift+t hotkey", async () => {
+    const container = await renderWithTitle("Before hotkey");
+
+    promptAnswer = "After hotkey";
+    await act(async () => {
+      pressKey({ key: "T", code: "KeyT", ctrl: true, shift: true });
+      await Promise.resolve();
+    });
+
+    expect(promptCalls).toEqual(["Edit Title"]);
+    expect(heading(container).textContent).toBe("After hotkey");
+  });
+
+  it("ignores the hotkey when the shift modifier is missing", async () => {
+    await renderWithTitle("Untouched");
+
+    await act(async () => {
+      pressKey({ key: "T", code: "KeyT", ctrl: true });
+      await Promise.resolve();
+    });
+
+    expect(promptCalls).toEqual([]);
+  });
+
+  it("describes a filled title for assistive technology", async () => {
+    const container = await renderWithTitle("My talk");
+
+    expect(heading(container).getAttribute("aria-label")).toBe(
+      "Title text: My talk. Click to edit title.",
+    );
+  });
+
+  it("describes a whitespace-only title as empty for assistive technology", async () => {
+    const container = await renderWithTitle("   ");
+
+    expect(heading(container).getAttribute("aria-label")).toBe(
+      "Empty title. Click to add title.",
+    );
+  });
+
+  it("announces its keyboard shortcut", async () => {
+    const container = await renderWithTitle("Shortcut");
+
+    expect(heading(container).getAttribute("aria-keyshortcuts")).toBe(
+      "Control+Shift+T to edit title text",
+    );
+  });
+
+  it("renders the clock alongside the title", async () => {
+    const container = await renderWithTitle("With clock");
+
+    expect(
+      container.querySelector("[data-testid='time-display']"),
+    ).not.toBeNull();
+  });
+});

--- a/src/components/layout/MainLayout.spec.tsx
+++ b/src/components/layout/MainLayout.spec.tsx
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import MainLayout from "./MainLayout.tsx";
+import { StorageName } from "@/stores";
+
+/**
+ * Renders the whole layout tree for real: `SkipLink`, `Header`, `TimeDisplay`,
+ * `MainContent`, the dnd-kit powered `QuestionList` with its `QuestionItem`
+ * rows, the `qrcode.react` powered `QrCodeComponent`, and `Footer`. No child is
+ * stubbed, so a breaking change in dnd-kit, radix, qrcode.react or the stores
+ * surfaces as a failure here rather than as a green test over a fake tree.
+ */
+describe("MainLayout", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.LAYOUT);
+    localStorage.removeItem(StorageName.QUESTIONS);
+    localStorage.removeItem(StorageName.QR_CODE);
+    vi.stubGlobal("prompt", () => null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the layout container", async () => {
+    const { container } = await render(<MainLayout />);
+
+    expect(
+      container.querySelector("[data-testid='main-layout-container']"),
+    ).not.toBeNull();
+  });
+
+  it("puts a skip link first in the DOM so keyboard users reach it immediately", async () => {
+    const { container } = await render(<MainLayout />);
+
+    const layout = container.querySelector(
+      "[data-testid='main-layout-container']",
+    );
+    const first = layout?.firstElementChild;
+
+    expect(first?.tagName).toBe("A");
+    expect(first?.textContent).toBe("Skip to content");
+    expect(first?.getAttribute("href")).toBe("#question-text-0");
+    expect(first?.getAttribute("aria-keyshortcuts")).toBe("Control+Shift+E");
+  });
+
+  it("points the skip link at an element that actually exists", async () => {
+    const { container } = await render(<MainLayout />);
+
+    const href = container
+      .querySelector("[data-testid='main-layout-container'] > a")
+      ?.getAttribute("href");
+    expect(href).toBe("#question-text-0");
+    expect(container.querySelector("#question-text-0")).not.toBeNull();
+  });
+
+  it("renders header, main, aside and footer landmarks", async () => {
+    const { container } = await render(<MainLayout />);
+
+    expect(container.querySelector("header")).not.toBeNull();
+    expect(container.querySelector("main")).not.toBeNull();
+    expect(container.querySelector("aside")).not.toBeNull();
+    expect(container.querySelector("footer")).not.toBeNull();
+  });
+
+  it("renders the question list with the questions held in the store", async () => {
+    const { container } = await render(<MainLayout />);
+
+    const list = container.querySelector("[role='list']");
+    expect(list).not.toBeNull();
+    expect(list?.querySelectorAll("[role='listitem']").length).toBeGreaterThan(
+      0,
+    );
+    expect(container.querySelectorAll("textarea").length).toBeGreaterThan(0);
+  });
+
+  it("renders the QR code placeholder in the aside", async () => {
+    const { container } = await render(<MainLayout />);
+
+    const aside = container.querySelector("aside");
+    expect(aside?.querySelector("[data-testid='qr-code']")).not.toBeNull();
+  });
+
+  it("announces the fullscreen shortcut on the content wrapper", async () => {
+    const { container } = await render(<MainLayout />);
+
+    expect(
+      container.querySelector("[aria-keyshortcuts]")?.closest("div"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        "[aria-keyshortcuts='Control+f to make website full screen']",
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/src/components/layout/TimeDisplay.spec.tsx
+++ b/src/components/layout/TimeDisplay.spec.tsx
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { act } from "@testing-library/react";
+import TimeDisplay from "./TimeDisplay.tsx";
+import { StorageName } from "@/stores";
+
+/**
+ * Renders the real component against the real preferences store and the real
+ * `Intl`-backed `Date#toLocaleTimeString`, so a regression in either the store
+ * wiring or the formatting shows up here.
+ */
+describe("TimeDisplay", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.PREFERENCES);
+  });
+
+  const button = (container: HTMLElement): HTMLButtonElement => {
+    const el = container.querySelector<HTMLButtonElement>(
+      "[data-testid='time-display']",
+    );
+    if (!el) throw new Error("time display button not rendered");
+    return el;
+  };
+
+  const click = async (el: HTMLElement): Promise<void> => {
+    await act(async () => {
+      el.click();
+      await Promise.resolve();
+    });
+  };
+
+  /**
+   * The preferences store is shared by every test in this file, so put it into
+   * a known 24h state before asserting anything.
+   */
+  const renderIn24h = async (): Promise<HTMLElement> => {
+    const { container } = await render(<TimeDisplay />);
+    if (button(container).dataset.timeFormat !== "24h") {
+      await click(button(container));
+    }
+    return container;
+  };
+
+  it("renders a 24 hour time by default", async () => {
+    const container = await renderIn24h();
+
+    expect(button(container).dataset.timeFormat).toBe("24h");
+    expect(button(container).textContent).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it("switches to a 12 hour time when clicked", async () => {
+    const container = await renderIn24h();
+
+    await click(button(container));
+
+    expect(button(container).dataset.timeFormat).toBe("12h");
+    expect(button(container).textContent).toMatch(/^\d{1,2}:\d{2}\s?[AP]M$/i);
+  });
+
+  it("switches back to 24 hour time on a second click", async () => {
+    const container = await renderIn24h();
+
+    await click(button(container));
+    await click(button(container));
+
+    expect(button(container).dataset.timeFormat).toBe("24h");
+    expect(button(container).textContent).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it("exposes the rendered time in its accessible name", async () => {
+    const container = await renderIn24h();
+    const el = button(container);
+
+    expect(el.getAttribute("aria-label")).toBe(`Time: ${el.textContent ?? ""}`);
+  });
+
+  it("keeps the accessible name in sync after toggling the format", async () => {
+    const container = await renderIn24h();
+
+    await click(button(container));
+
+    const el = button(container);
+    expect(el.getAttribute("aria-label")).toBe(`Time: ${el.textContent ?? ""}`);
+  });
+});

--- a/src/components/onboarding/GuidedTour.spec.tsx
+++ b/src/components/onboarding/GuidedTour.spec.tsx
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import GuidedTour from "./GuidedTour.tsx";
+import { steps } from "./guided-tour-steps.ts";
+import MainLayout from "../layout/MainLayout.tsx";
+import App from "@/App.tsx";
+import {
+  StorageName,
+  useCompleteTour,
+  useRestartTour,
+  useTourCompleted,
+} from "@/stores";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Drives the real `react-joyride` tour over the real application layout, so the
+ * step targets are resolved against real DOM nodes. A regression in joyride, or
+ * a step whose selector no longer matches anything the app renders, fails here.
+ */
+describe("GuidedTour", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.ONBOARDING);
+    localStorage.removeItem(StorageName.QUESTIONS);
+    localStorage.removeItem(StorageName.QR_CODE);
+    vi.stubGlobal("prompt", () => null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const tourHook = () =>
+    renderHook(() => ({
+      tourCompleted: useTourCompleted(),
+      completeTour: useCompleteTour(),
+      restartTour: useRestartTour(),
+    }));
+
+  const renderTour = async (completed: boolean) => {
+    const hook = tourHook();
+    act(() => {
+      if (completed) hook.result.current.completeTour();
+      else hook.result.current.restartTour();
+    });
+    const rendered = await render(
+      <>
+        <MainLayout />
+        <GuidedTour />
+      </>,
+    );
+    return { ...rendered, hook };
+  };
+
+  const portal = (): HTMLElement | null =>
+    document.getElementById("react-joyride-portal");
+
+  const tooltip = (): HTMLElement | null =>
+    document.getElementById("joyride-tooltip-content");
+
+  const joyrideButton = (name: string): HTMLElement | null =>
+    document.body.querySelector<HTMLElement>(`[data-testid='button-${name}']`);
+
+  const waitForTooltip = async (): Promise<void> => {
+    await vi.waitFor(
+      () => {
+        if (!tooltip()) throw new Error("joyride tooltip not rendered yet");
+      },
+      { timeout: 3000 },
+    );
+  };
+
+  it("starts the tour while it has not been completed", async () => {
+    await renderTour(false);
+
+    await waitForTooltip();
+
+    expect(portal()).not.toBeNull();
+    expect(tooltip()?.textContent).toBe(steps[0].content);
+  });
+
+  it("offers skip, next and close controls", async () => {
+    await renderTour(false);
+    await waitForTooltip();
+
+    expect(joyrideButton("skip")?.textContent).toBe("Skip");
+    expect(joyrideButton("primary")?.textContent).toBe("Next");
+    expect(joyrideButton("close")).not.toBeNull();
+  });
+
+  it("advances to the next documented step", async () => {
+    await renderTour(false);
+    await waitForTooltip();
+
+    await interact(() => joyrideButton("primary")?.click());
+    await vi.waitFor(() => {
+      if (tooltip()?.textContent !== steps[1].content) {
+        throw new Error("still on the first step");
+      }
+    });
+
+    expect(tooltip()?.textContent).toBe(steps[1].content);
+  });
+
+  it("marks the tour completed when it is skipped", async () => {
+    const { hook } = await renderTour(false);
+    await waitForTooltip();
+    expect(hook.result.current.tourCompleted).toBe(false);
+
+    await interact(() => joyrideButton("skip")?.click());
+    await vi.waitFor(() => {
+      if (!hook.result.current.tourCompleted) {
+        throw new Error("tour not marked completed yet");
+      }
+    });
+
+    expect(hook.result.current.tourCompleted).toBe(true);
+  });
+
+  it("tears the tour down once it is completed", async () => {
+    await renderTour(false);
+    await waitForTooltip();
+
+    await interact(() => joyrideButton("skip")?.click());
+    await vi.waitFor(() => {
+      if (tooltip()) throw new Error("tooltip still visible");
+    });
+
+    expect(tooltip()).toBeNull();
+  });
+
+  it("does not run at all for a returning user", async () => {
+    await renderTour(true);
+
+    // Give joyride the same amount of time it needs to mount a running tour.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(tooltip()).toBeNull();
+  });
+});
+
+describe("guided tour steps", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.QUESTIONS);
+    localStorage.removeItem(StorageName.QR_CODE);
+    vi.stubGlobal("prompt", () => null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("every step targets an element the application actually renders", async () => {
+    // Rendered against the whole app, because some steps point at chrome that
+    // lives outside the layout (the help icon, for instance).
+    const hook = renderHook(() => useCompleteTour());
+    act(() => {
+      hook.result.current();
+    });
+    await render(<App />);
+
+    for (const step of steps) {
+      const target = step.target;
+      if (typeof target !== "string") {
+        throw new Error("every tour step is expected to use a css selector");
+      }
+      expect(
+        document.body.querySelector(target),
+        `no element matches step target ${target}`,
+      ).not.toBeNull();
+    }
+  });
+
+  it("every step carries content", () => {
+    expect(steps.length).toBeGreaterThan(0);
+    for (const step of steps) {
+      const content = step.content;
+      if (typeof content !== "string") {
+        throw new Error("every tour step is expected to carry text content");
+      }
+      expect(content.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/components/qr/FullScreenQrCode.spec.tsx
+++ b/src/components/qr/FullScreenQrCode.spec.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import { FullScreenQrCode } from "./FullScreenQrCode.tsx";
+import { StorageName, useSetQrCodeUrl } from "@/stores";
+import { pressKey } from "@/test-utils/keyboard.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Exercises the real component with the real `react-hotkeys-hook` binding and
+ * the real `qrcode.react` renderer behind it.
+ */
+describe("FullScreenQrCode", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.QR_CODE);
+  });
+
+  /** The QR store is shared by this file, so set the url explicitly. */
+  const renderWithUrl = async (url: string) => {
+    const { result } = renderHook(() => useSetQrCodeUrl());
+    act(() => {
+      result.current(url);
+    });
+    return render(<FullScreenQrCode />);
+  };
+
+  const toggle = async () => {
+    await interact(() => {
+      pressKey({ key: "q", code: "KeyQ", ctrl: true });
+    });
+  };
+
+  const overlay = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector("[data-testid='fullscreen-qr-code']");
+
+  it("renders nothing until the shortcut is pressed", async () => {
+    const { container } = await renderWithUrl("https://example.com/talk");
+
+    expect(overlay(container)).toBeNull();
+  });
+
+  it("shows a full screen QR code on ctrl+q", async () => {
+    const { container } = await renderWithUrl("https://example.com/talk");
+
+    await toggle();
+
+    expect(overlay(container)).not.toBeNull();
+    const paths = overlay(container)?.querySelectorAll("svg path") ?? [];
+    expect(paths.length).toBeGreaterThan(0);
+  });
+
+  it("hides again when ctrl+q is pressed a second time", async () => {
+    const { container } = await renderWithUrl("https://example.com/talk");
+
+    await toggle();
+    await toggle();
+
+    expect(overlay(container)).toBeNull();
+  });
+
+  it("hides when the overlay is clicked", async () => {
+    const { container } = await renderWithUrl("https://example.com/talk");
+
+    await toggle();
+    const el = overlay(container);
+    expect(el).not.toBeNull();
+
+    await interact(() => el?.click());
+
+    expect(overlay(container)).toBeNull();
+  });
+
+  it("stays hidden when no url is configured", async () => {
+    const { container } = await renderWithUrl("");
+
+    await toggle();
+
+    expect(overlay(container)).toBeNull();
+  });
+
+  it("exposes itself as a labelled modal dialog", async () => {
+    const { container } = await renderWithUrl("https://example.com/talk");
+
+    await toggle();
+
+    const el = overlay(container);
+    expect(el?.getAttribute("role")).toBe("dialog");
+    expect(el?.getAttribute("aria-modal")).toBe("true");
+    expect(el?.getAttribute("aria-label")).toBe("Full Screen QR Code");
+    expect(el?.getAttribute("aria-keyshortcuts")).toBe(
+      "Control+q to hide full screen qr code",
+    );
+  });
+});

--- a/src/components/qr/QrCodeComponent.spec.tsx
+++ b/src/components/qr/QrCodeComponent.spec.tsx
@@ -1,0 +1,523 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import QrCodeComponent from "./QrCodeComponent.tsx";
+import { StorageName, useSetQrCodeSize, useSetQrCodeUrl } from "@/stores";
+import { keyDown, pressKey } from "@/test-utils/keyboard.ts";
+import { interact } from "@/test-utils/react.ts";
+
+const DEFAULT_SIZE = 100;
+const MIN_SIZE = 32;
+const MAX_SIZE = 256;
+
+/**
+ * Exercises the real component together with the real `qrcode.react` renderer,
+ * the real `@react-aria/interactions` move handling and the real zustand QR
+ * store. The generated SVG is asserted on directly, so a regression in
+ * qrcode.react (or in the size plumbing) fails the test.
+ */
+describe("QrCodeComponent", () => {
+  let promptCalls: (string | undefined)[] = [];
+  let promptAnswer: string | null = null;
+
+  beforeEach(() => {
+    promptCalls = [];
+    promptAnswer = null;
+    localStorage.removeItem(StorageName.QR_CODE);
+    vi.stubGlobal("prompt", (message?: string) => {
+      promptCalls.push(message);
+      return promptAnswer;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const storeSetters = () =>
+    renderHook(() => ({
+      setUrl: useSetQrCodeUrl(),
+      setSize: useSetQrCodeSize(),
+    }));
+
+  /**
+   * The QR store is shared by every test in this file, so put it into a known
+   * state before rendering.
+   */
+  const renderWith = async (url: string, size = DEFAULT_SIZE) => {
+    const { result } = storeSetters();
+    act(() => {
+      result.current.setUrl(url);
+    });
+    act(() => {
+      result.current.setSize(size);
+    });
+    return render(<QrCodeComponent />);
+  };
+
+  const wrapper = (container: HTMLElement): HTMLElement => {
+    const el = container.querySelector<HTMLElement>("[data-testid='qr-code']");
+    if (!el) throw new Error("qr code wrapper not rendered");
+    return el;
+  };
+
+  it("shows a placeholder instead of a QR code when no url is set", async () => {
+    const { container } = await renderWith("");
+
+    expect(
+      container.querySelector("[data-testid='qr-code-placeholder']"),
+    ).not.toBeNull();
+    expect(container.querySelector("[data-testid='qr-code-svg']")).toBeNull();
+    expect(wrapper(container).getAttribute("aria-label")).toBe(
+      "No QR Code set. Click to enter a URL",
+    );
+  });
+
+  it("renders a real QR code svg once a url is set", async () => {
+    const { container } = await renderWith("https://example.com/talk");
+
+    const svg = container.querySelector<SVGSVGElement>(
+      "[data-testid='qr-code-svg']",
+    );
+    expect(svg).not.toBeNull();
+    expect(svg?.tagName.toLowerCase()).toBe("svg");
+    // qrcode.react emits the modules as path data; an empty path would mean
+    // the encoder produced nothing.
+    const paths = svg?.querySelectorAll("path") ?? [];
+    expect(paths.length).toBeGreaterThan(0);
+    expect(
+      Array.from(paths).some((p) => (p.getAttribute("d") ?? "").length > 20),
+    ).toBe(true);
+  });
+
+  it("encodes different urls into different QR module data", async () => {
+    const first = await renderWith("https://example.com/one");
+    const firstPaths = Array.from(
+      first.container.querySelectorAll("[data-testid='qr-code-svg'] path"),
+    )
+      .map((p) => p.getAttribute("d"))
+      .join("");
+
+    const second = await renderWith("https://example.com/a-different-url");
+    const secondPaths = Array.from(
+      second.container.querySelectorAll("[data-testid='qr-code-svg'] path"),
+    )
+      .map((p) => p.getAttribute("d"))
+      .join("");
+
+    expect(firstPaths.length).toBeGreaterThan(0);
+    expect(secondPaths).not.toBe(firstPaths);
+  });
+
+  it("renders the QR code at the size held in the store", async () => {
+    const { container } = await renderWith("https://example.com/talk", 128);
+
+    const svg = container.querySelector<SVGSVGElement>(
+      "[data-testid='qr-code-svg']",
+    );
+    expect(svg?.getAttribute("width")).toBe("128");
+    expect(svg?.getAttribute("height")).toBe("128");
+  });
+
+  it("asks for a new url when clicked and stores the answer", async () => {
+    const { container } = await renderWith("https://example.com/old");
+
+    promptAnswer = "https://example.com/new";
+    await interact(() => wrapper(container).click());
+
+    expect(promptCalls).toEqual(["Enter QR Code URL"]);
+    expect(wrapper(container).getAttribute("aria-label")).toBe(
+      "QR Code. Click to change the URL",
+    );
+  });
+
+  it("keeps the url when the prompt is cancelled", async () => {
+    const { container } = await renderWith("https://example.com/keep");
+
+    promptAnswer = null;
+    await interact(() => wrapper(container).click());
+
+    expect(
+      container.querySelector("[data-testid='qr-code-svg']"),
+    ).not.toBeNull();
+  });
+
+  it("hides the QR code when the url is cleared through the prompt", async () => {
+    const { container } = await renderWith("https://example.com/clear-me");
+
+    promptAnswer = "";
+    await interact(() => wrapper(container).click());
+
+    expect(
+      container.querySelector("[data-testid='qr-code-placeholder']"),
+    ).not.toBeNull();
+  });
+
+  it("opens the url prompt via the ctrl+shift+q hotkey", async () => {
+    await renderWith("https://example.com/hotkey");
+
+    promptAnswer = null;
+    await interact(() => {
+      pressKey({ key: "Q", code: "KeyQ", ctrl: true, shift: true });
+    });
+
+    expect(promptCalls).toEqual(["Enter QR Code URL"]);
+  });
+
+  it("opens the url prompt when Enter is pressed on the wrapper", async () => {
+    const { container } = await renderWith("https://example.com/enter");
+
+    promptAnswer = null;
+    await interact(() => {
+      keyDown({ key: "Enter", code: "Enter", target: wrapper(container) });
+    });
+
+    expect(promptCalls).toEqual(["Enter QR Code URL"]);
+  });
+
+  it("opens the url prompt when Space is pressed on the wrapper", async () => {
+    const { container } = await renderWith("https://example.com/space");
+
+    promptAnswer = null;
+    await interact(() => {
+      keyDown({ key: " ", code: "Space", target: wrapper(container) });
+    });
+
+    expect(promptCalls).toEqual(["Enter QR Code URL"]);
+  });
+
+  it("ignores unrelated keys on the wrapper", async () => {
+    const { container } = await renderWith("https://example.com/ignore");
+
+    await interact(() => {
+      keyDown({ key: "a", code: "KeyA", target: wrapper(container) });
+    });
+
+    expect(promptCalls).toEqual([]);
+  });
+
+  it("only offers resize handles once a url is set", async () => {
+    const empty = await renderWith("");
+    expect(
+      empty.container.querySelector(
+        "[data-testid='qr-code-resize-bottom-right']",
+      ),
+    ).toBeNull();
+
+    const filled = await renderWith("https://example.com/handles");
+    expect(
+      filled.container.querySelector(
+        "[data-testid='qr-code-resize-bottom-right']",
+      ),
+    ).not.toBeNull();
+    expect(
+      filled.container.querySelector(
+        "[data-testid='qr-code-resize-bottom-left']",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("exposes the resize handles as sliders with the current size", async () => {
+    const { container } = await renderWith("https://example.com/aria", 120);
+
+    const handle = container.querySelector(
+      "[data-testid='qr-code-resize-bottom-right']",
+    );
+    expect(handle?.getAttribute("role")).toBe("slider");
+    expect(handle?.getAttribute("aria-label")).toBe("Resize bottom right");
+    expect(handle?.getAttribute("aria-valuemin")).toBe(String(MIN_SIZE));
+    expect(handle?.getAttribute("aria-valuemax")).toBe(String(MAX_SIZE));
+    expect(handle?.getAttribute("aria-valuenow")).toBe("120");
+    expect(handle?.getAttribute("aria-valuetext")).toBe("120px");
+  });
+
+  const handleAt = (
+    container: HTMLElement,
+    corner: "right" | "left",
+  ): HTMLElement => {
+    const el = container.querySelector<HTMLElement>(
+      `[data-testid='qr-code-resize-bottom-${corner}']`,
+    );
+    if (!el) throw new Error(`resize handle ${corner} not rendered`);
+    return el;
+  };
+
+  const svgWidth = (container: HTMLElement): string | null | undefined =>
+    container
+      .querySelector("[data-testid='qr-code-svg']")
+      ?.getAttribute("width");
+
+  it("grows the QR code by 4px per arrow key press", async () => {
+    const { container } = await renderWith("https://example.com/grow", 100);
+
+    await interact(() => {
+      keyDown({
+        key: "ArrowRight",
+        code: "ArrowRight",
+        target: handleAt(container, "right"),
+      });
+    });
+
+    expect(svgWidth(container)).toBe("104");
+  });
+
+  it("grows the QR code by 16px when shift is held", async () => {
+    const { container } = await renderWith(
+      "https://example.com/grow-fast",
+      100,
+    );
+
+    await interact(() => {
+      keyDown({
+        key: "ArrowUp",
+        code: "ArrowUp",
+        shift: true,
+        target: handleAt(container, "right"),
+      });
+    });
+
+    expect(svgWidth(container)).toBe("116");
+  });
+
+  it("shrinks the QR code with the left and down arrows", async () => {
+    const { container } = await renderWith("https://example.com/shrink", 100);
+
+    await interact(() => {
+      keyDown({
+        key: "ArrowLeft",
+        code: "ArrowLeft",
+        target: handleAt(container, "left"),
+      });
+    });
+    await interact(() => {
+      keyDown({
+        key: "ArrowDown",
+        code: "ArrowDown",
+        target: handleAt(container, "left"),
+      });
+    });
+
+    expect(svgWidth(container)).toBe("92");
+  });
+
+  it("clamps the size at the 256px maximum", async () => {
+    const { container } = await renderWith("https://example.com/max", 250);
+
+    await interact(() => {
+      keyDown({
+        key: "ArrowRight",
+        code: "ArrowRight",
+        shift: true,
+        target: handleAt(container, "right"),
+      });
+    });
+
+    expect(svgWidth(container)).toBe(String(MAX_SIZE));
+  });
+
+  it("clamps the size at the 32px minimum", async () => {
+    const { container } = await renderWith("https://example.com/min", 34);
+
+    await interact(() => {
+      keyDown({
+        key: "ArrowLeft",
+        code: "ArrowLeft",
+        shift: true,
+        target: handleAt(container, "right"),
+      });
+    });
+
+    expect(svgWidth(container)).toBe(String(MIN_SIZE));
+  });
+
+  it("leaves the size alone for keys that are not arrows", async () => {
+    const { container } = await renderWith("https://example.com/noop", 100);
+
+    await interact(() => {
+      keyDown({
+        key: "a",
+        code: "KeyA",
+        target: handleAt(container, "right"),
+      });
+    });
+
+    expect(svgWidth(container)).toBe("100");
+  });
+
+  it("prevents the default scroll behaviour of the arrow keys", async () => {
+    const { container } = await renderWith("https://example.com/prevent", 100);
+
+    let event!: KeyboardEvent;
+    await interact(() => {
+      event = keyDown({
+        key: "ArrowRight",
+        code: "ArrowRight",
+        target: handleAt(container, "right"),
+      });
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});
+
+/**
+ * Pointer driven resizing goes through the real `useMove` hook from
+ * `@react-aria/interactions`: the tests dispatch genuine `PointerEvent`s and
+ * assert the size the component derives from the deltas react-aria reports.
+ */
+describe("QrCodeComponent pointer resizing", () => {
+  let promptCalls: (string | undefined)[] = [];
+
+  beforeEach(() => {
+    promptCalls = [];
+    localStorage.removeItem(StorageName.QR_CODE);
+    vi.stubGlobal("prompt", (message?: string) => {
+      promptCalls.push(message);
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const renderAtSize = async (size: number) => {
+    const { result } = renderHook(() => ({
+      setUrl: useSetQrCodeUrl(),
+      setSize: useSetQrCodeSize(),
+    }));
+    act(() => {
+      result.current.setUrl("https://example.com/resize");
+    });
+    act(() => {
+      result.current.setSize(size);
+    });
+    return render(<QrCodeComponent />);
+  };
+
+  const pointer = (
+    type: string,
+    init: PointerEventInit & { clientX: number; clientY: number },
+  ): PointerEvent =>
+    new PointerEvent(type, {
+      pointerId: 1,
+      pointerType: "mouse",
+      button: 0,
+      buttons: 1,
+      isPrimary: true,
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    });
+
+  /** Performs a real pointer drag on one of the resize handles. */
+  const drag = async (
+    container: HTMLElement,
+    corner: "right" | "left",
+    dx: number,
+    dy: number,
+  ): Promise<void> => {
+    const handle = container.querySelector<HTMLElement>(
+      `[data-testid='qr-code-resize-bottom-${corner}']`,
+    );
+    if (!handle) throw new Error(`resize handle ${corner} not rendered`);
+
+    await interact(() => {
+      handle.dispatchEvent(
+        pointer("pointerdown", { clientX: 200, clientY: 200 }),
+      );
+    });
+    await interact(() => {
+      window.dispatchEvent(
+        pointer("pointermove", { clientX: 200 + dx, clientY: 200 + dy }),
+      );
+    });
+    await interact(() => {
+      window.dispatchEvent(
+        pointer("pointerup", {
+          clientX: 200 + dx,
+          clientY: 200 + dy,
+          buttons: 0,
+        }),
+      );
+    });
+  };
+
+  const svgWidth = (container: HTMLElement): string | null | undefined =>
+    container
+      .querySelector("[data-testid='qr-code-svg']")
+      ?.getAttribute("width");
+
+  it("grows the QR code when the bottom right handle is dragged outwards", async () => {
+    const { container } = await renderAtSize(100);
+
+    await drag(container, "right", 40, 0);
+
+    await vi.waitFor(() => {
+      if (svgWidth(container) !== "140") {
+        throw new Error(`size is ${String(svgWidth(container))}`);
+      }
+    });
+    expect(svgWidth(container)).toBe("140");
+  });
+
+  it("grows the QR code when the bottom left handle is dragged outwards", async () => {
+    const { container } = await renderAtSize(100);
+
+    await drag(container, "left", -40, 0);
+
+    await vi.waitFor(() => {
+      if (svgWidth(container) !== "140") {
+        throw new Error(`size is ${String(svgWidth(container))}`);
+      }
+    });
+    expect(svgWidth(container)).toBe("140");
+  });
+
+  it("clamps a pointer drag to the maximum size", async () => {
+    const { container } = await renderAtSize(200);
+
+    await drag(container, "right", 400, 0);
+
+    await vi.waitFor(() => {
+      if (svgWidth(container) !== String(MAX_SIZE)) {
+        throw new Error(`size is ${String(svgWidth(container))}`);
+      }
+    });
+    expect(svgWidth(container)).toBe(String(MAX_SIZE));
+  });
+
+  it("clamps a pointer drag to the minimum size", async () => {
+    const { container } = await renderAtSize(100);
+
+    await drag(container, "right", -400, -400);
+
+    await vi.waitFor(() => {
+      if (svgWidth(container) !== String(MIN_SIZE)) {
+        throw new Error(`size is ${String(svgWidth(container))}`);
+      }
+    });
+    expect(svgWidth(container)).toBe(String(MIN_SIZE));
+  });
+
+  it("restores the document's text selection after a drag", async () => {
+    const { container } = await renderAtSize(100);
+    const before = document.body.style.userSelect;
+
+    await drag(container, "right", 20, 0);
+
+    expect(document.body.style.userSelect).toBe(before);
+  });
+
+  it("does not treat the end of a drag as a click on the QR code", async () => {
+    const { container } = await renderAtSize(100);
+
+    await drag(container, "right", 20, 0);
+    const promptsBefore = promptCalls.length;
+    await interact(() => {
+      container.querySelector<HTMLElement>("[data-testid='qr-code']")?.click();
+    });
+
+    expect(promptCalls.length).toBe(promptsBefore);
+  });
+});

--- a/src/components/questions/ClearQuestionsModal.spec.tsx
+++ b/src/components/questions/ClearQuestionsModal.spec.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import { ClearQuestionsModal } from "./ClearQuestionsModal.tsx";
+import { StorageName, useQuestions, useSetQuestions } from "@/stores";
+import { pressKey } from "@/test-utils/keyboard.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Exercises the real confirmation flow end to end: the real
+ * `react-hotkeys-hook` binding, the real `Modal` built on Radix's dialog
+ * primitive, the real `react-focus-lock` wrapper, and the real zustand
+ * questions store. Radix renders the dialog into a portal on `document.body`,
+ * so the assertions query the document rather than the render container.
+ */
+describe("ClearQuestionsModal", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.QUESTIONS);
+  });
+
+  const questionsHook = () =>
+    renderHook(() => ({
+      questions: useQuestions(),
+      setQuestions: useSetQuestions(),
+    }));
+
+  const renderWithQuestions = async () => {
+    const hook = questionsHook();
+    act(() => {
+      hook.result.current.setQuestions([
+        { id: "a", text: "First", answered: false, highlighted: false },
+        { id: "b", text: "Second", answered: true, highlighted: false },
+        { id: "c", text: "Third", answered: false, highlighted: true },
+      ]);
+    });
+    const rendered = await render(<ClearQuestionsModal />);
+    return { ...rendered, hook };
+  };
+
+  const openModal = async () => {
+    await interact(() => {
+      pressKey({
+        key: "Backspace",
+        code: "Backspace",
+        ctrl: true,
+        shift: true,
+      });
+    });
+  };
+
+  const dialog = (): HTMLElement | null =>
+    document.body.querySelector("[role='dialog']");
+
+  const byTestId = (id: string): HTMLElement | null =>
+    document.body.querySelector(`[data-testid='${id}']`);
+
+  it("stays closed until the shortcut is pressed", async () => {
+    await renderWithQuestions();
+
+    expect(dialog()).toBeNull();
+  });
+
+  it("opens on ctrl+shift+backspace with the confirmation copy", async () => {
+    await renderWithQuestions();
+
+    await openModal();
+
+    expect(dialog()).not.toBeNull();
+    expect(dialog()?.textContent).toContain("Confirm Clear");
+    expect(dialog()?.textContent).toContain(
+      "Are you sure you want to clear the list?",
+    );
+    expect(byTestId("modal-confirm")?.textContent).toBe("Clear");
+    expect(byTestId("modal-cancel")?.textContent).toBe("Cancel");
+  });
+
+  it("clears the questions when confirmed", async () => {
+    const { hook } = await renderWithQuestions();
+    expect(hook.result.current.questions).toHaveLength(3);
+
+    await openModal();
+    await interact(() => byTestId("modal-confirm")?.click());
+
+    expect(hook.result.current.questions).toHaveLength(1);
+    expect(hook.result.current.questions[0].text).toBe("");
+    expect(hook.result.current.questions[0].answered).toBe(false);
+    expect(hook.result.current.questions[0].highlighted).toBe(false);
+  });
+
+  it("closes itself after confirming", async () => {
+    await renderWithQuestions();
+
+    await openModal();
+    await interact(() => byTestId("modal-confirm")?.click());
+
+    expect(dialog()).toBeNull();
+  });
+
+  it("leaves the questions untouched when cancelled", async () => {
+    const { hook } = await renderWithQuestions();
+
+    await openModal();
+    await interact(() => byTestId("modal-cancel")?.click());
+
+    expect(dialog()).toBeNull();
+    expect(hook.result.current.questions).toHaveLength(3);
+    expect(hook.result.current.questions[1].text).toBe("Second");
+  });
+
+  it("can be dismissed with the dialog close button", async () => {
+    const { hook } = await renderWithQuestions();
+
+    await openModal();
+    await interact(() => byTestId("modal-close")?.click());
+
+    expect(dialog()).toBeNull();
+    expect(hook.result.current.questions).toHaveLength(3);
+  });
+
+  it("moves focus into the dialog when it opens", async () => {
+    await renderWithQuestions();
+
+    await openModal();
+
+    expect(dialog()?.contains(document.activeElement)).toBe(true);
+  });
+
+  it("can be reopened after being cancelled", async () => {
+    await renderWithQuestions();
+
+    await openModal();
+    await interact(() => byTestId("modal-cancel")?.click());
+    await openModal();
+
+    expect(dialog()).not.toBeNull();
+  });
+});

--- a/src/components/questions/QuestionList.spec.tsx
+++ b/src/components/questions/QuestionList.spec.tsx
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { renderHook, act } from "@testing-library/react";
+import QuestionList from "./QuestionList.tsx";
+import { StorageName, useQuestions, useSetQuestions } from "@/stores";
+import { keyDown } from "@/test-utils/keyboard.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Exercises the real `@dnd-kit` stack: `DndContext`, `SortableContext`, the
+ * keyboard sensor with `sortableKeyboardCoordinates`, and `arrayMove`. The
+ * reorder is performed by driving dnd-kit's real keyboard drag protocol, so a
+ * breaking change in dnd-kit fails this test instead of slipping through.
+ */
+describe("QuestionList", () => {
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.QUESTIONS);
+  });
+
+  const questionsHook = () =>
+    renderHook(() => ({
+      questions: useQuestions(),
+      setQuestions: useSetQuestions(),
+    }));
+
+  const renderList = async () => {
+    const hook = questionsHook();
+    act(() => {
+      hook.result.current.setQuestions([
+        { id: "a", text: "Alpha", answered: false, highlighted: false },
+        { id: "b", text: "Bravo", answered: false, highlighted: false },
+        { id: "c", text: "Charlie", answered: false, highlighted: false },
+      ]);
+    });
+    const rendered = await render(<QuestionList />);
+    return { ...rendered, hook };
+  };
+
+  const texts = (container: HTMLElement): string[] =>
+    Array.from(container.querySelectorAll("textarea")).map((t) => t.value);
+
+  it("renders one list item per question, in store order", async () => {
+    const { container } = await renderList();
+
+    expect(container.querySelectorAll("[role='listitem']")).toHaveLength(3);
+    expect(texts(container)).toEqual(["Alpha", "Bravo", "Charlie"]);
+  });
+
+  it("gives every question its own textarea id for the skip link", async () => {
+    const { container } = await renderList();
+
+    const ids = Array.from(container.querySelectorAll("textarea")).map(
+      (t) => t.id,
+    );
+    expect(ids).toEqual([
+      "question-text-0",
+      "question-text-1",
+      "question-text-2",
+    ]);
+  });
+
+  it("re-renders in the new order when the store changes", async () => {
+    const { container, hook } = await renderList();
+
+    await interact(() => {
+      hook.result.current.setQuestions([
+        { id: "c", text: "Charlie", answered: false, highlighted: false },
+        { id: "a", text: "Alpha", answered: false, highlighted: false },
+        { id: "b", text: "Bravo", answered: false, highlighted: false },
+      ]);
+    });
+
+    expect(texts(container)).toEqual(["Charlie", "Alpha", "Bravo"]);
+  });
+
+  it("reorders the store when a question is dragged down with the keyboard", async () => {
+    const { container, hook } = await renderList();
+
+    const handles = container.querySelectorAll<HTMLElement>(
+      "[data-testid='reorder-button']",
+    );
+    const first = handles[0];
+
+    // dnd-kit's keyboard sensor: Space picks the item up, an arrow key moves
+    // it, Space drops it and fires onDragEnd.
+    await interact(() => {
+      first.focus();
+      keyDown({ key: " ", code: "Space", target: first });
+    });
+    await interact(() => {
+      keyDown({ key: "ArrowDown", code: "ArrowDown", target: first });
+    });
+    await interact(() => {
+      keyDown({ key: " ", code: "Space", target: first });
+    });
+
+    await vi.waitFor(() => {
+      if (hook.result.current.questions[0].id !== "b") {
+        throw new Error(
+          `order is ${hook.result.current.questions.map((q) => q.id).join(",")}`,
+        );
+      }
+    });
+
+    expect(hook.result.current.questions.map((q) => q.id)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(texts(container)).toEqual(["Bravo", "Alpha", "Charlie"]);
+  });
+
+  it("leaves the order alone when a drag is cancelled", async () => {
+    const { hook } = await renderList();
+    const { container } = await render(<QuestionList />);
+
+    const first = container.querySelector<HTMLElement>(
+      "[data-testid='reorder-button']",
+    );
+    if (!first) throw new Error("reorder handle not rendered");
+
+    await interact(() => {
+      first.focus();
+      keyDown({ key: " ", code: "Space", target: first });
+    });
+    await interact(() => {
+      keyDown({ key: "ArrowDown", code: "ArrowDown", target: first });
+    });
+    await interact(() => {
+      keyDown({ key: "Escape", code: "Escape", target: first });
+    });
+
+    expect(hook.result.current.questions.map((q) => q.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("publishes a live region for dnd-kit's drag announcements", async () => {
+    await renderList();
+
+    const liveRegion = document.body.querySelector("[id^='DndLiveRegion-']");
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.getAttribute("role")).toBe("status");
+  });
+});

--- a/src/components/ui/alert-dialog.spec.tsx
+++ b/src/components/ui/alert-dialog.spec.tsx
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import { useState } from "react";
+import { render } from "vitest-browser-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog.tsx";
+import { buttonVariants } from "./button-variants.tsx";
+import { cn } from "@/lib/utils.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Exercises the real `@radix-ui/react-alert-dialog` primitive end to end:
+ * trigger, portal, overlay, focus handling and the action/cancel buttons.
+ * Radix renders into a portal on `document.body`, so assertions query the
+ * document. A breaking change in Radix's alert dialog fails these tests.
+ */
+describe("AlertDialog", () => {
+  const Harness = ({
+    onConfirm,
+    onCancel,
+  }: {
+    onConfirm?: () => void;
+    onCancel?: () => void;
+  }) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogTrigger data-testid="open">Delete</AlertDialogTrigger>
+        <AlertDialogContent data-testid="content">
+          <AlertDialogHeader data-testid="header">
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter data-testid="footer">
+            <AlertDialogCancel data-testid="cancel" onClick={onCancel}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction data-testid="confirm" onClick={onConfirm}>
+              Continue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  };
+
+  const byTestId = (id: string): HTMLElement | null =>
+    document.body.querySelector(`[data-testid='${id}']`);
+
+  const open = async () => {
+    await interact(() => byTestId("open")?.click());
+  };
+
+  it("keeps the dialog closed until the trigger is used", async () => {
+    await render(<Harness />);
+
+    expect(byTestId("content")).toBeNull();
+  });
+
+  it("opens with the alertdialog role", async () => {
+    await render(<Harness />);
+
+    await open();
+
+    expect(byTestId("content")).not.toBeNull();
+    expect(byTestId("content")?.getAttribute("role")).toBe("alertdialog");
+  });
+
+  it("wires the title and description to the dialog for screen readers", async () => {
+    await render(<Harness />);
+
+    await open();
+    const content = byTestId("content");
+    const labelledBy = content?.getAttribute("aria-labelledby");
+    const describedBy = content?.getAttribute("aria-describedby");
+
+    expect(document.getElementById(labelledBy ?? "")?.textContent).toBe(
+      "Are you absolutely sure?",
+    );
+    expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+      "This action cannot be undone.",
+    );
+  });
+
+  it("renders an overlay behind the dialog", async () => {
+    await render(<Harness />);
+
+    await open();
+
+    const overlay = document.body.querySelector("[data-state='open'].fixed");
+    expect(overlay).not.toBeNull();
+  });
+
+  it("moves focus into the dialog when it opens", async () => {
+    await render(<Harness />);
+
+    await open();
+
+    expect(byTestId("content")?.contains(document.activeElement)).toBe(true);
+  });
+
+  it("runs the action handler and closes", async () => {
+    let confirmed = 0;
+    await render(
+      <Harness
+        onConfirm={() => {
+          confirmed++;
+        }}
+      />,
+    );
+
+    await open();
+    await interact(() => byTestId("confirm")?.click());
+
+    expect(confirmed).toBe(1);
+    expect(byTestId("content")).toBeNull();
+  });
+
+  it("runs the cancel handler and closes", async () => {
+    let cancelled = 0;
+    await render(
+      <Harness
+        onCancel={() => {
+          cancelled++;
+        }}
+      />,
+    );
+
+    await open();
+    await interact(() => byTestId("cancel")?.click());
+
+    expect(cancelled).toBe(1);
+    expect(byTestId("content")).toBeNull();
+  });
+
+  it("styles the action button with the default button variant", async () => {
+    await render(<Harness />);
+
+    await open();
+
+    expect(byTestId("confirm")?.className).toBe(cn(buttonVariants()));
+  });
+
+  it("styles the cancel button with the outline variant", async () => {
+    await render(<Harness />);
+
+    await open();
+
+    const className = byTestId("cancel")?.className ?? "";
+    expect(className).toContain("mt-2");
+    expect(className).toContain("border");
+  });
+
+  it("lays out the header and footer with their own classes", async () => {
+    await render(<Harness />);
+
+    await open();
+
+    expect(byTestId("header")?.className).toContain("flex-col");
+    expect(byTestId("footer")?.className).toContain("flex-col-reverse");
+  });
+
+  it("can be reopened after being dismissed", async () => {
+    await render(<Harness />);
+
+    await open();
+    await interact(() => byTestId("cancel")?.click());
+    await open();
+
+    expect(byTestId("content")).not.toBeNull();
+  });
+
+  it("exports a portal and overlay that compose into a custom dialog", async () => {
+    await render(
+      <AlertDialog open>
+        <AlertDialogPortal>
+          <AlertDialogOverlay
+            data-testid="custom-overlay"
+            className="bg-red-500/50"
+          />
+        </AlertDialogPortal>
+      </AlertDialog>,
+    );
+
+    const overlay = byTestId("custom-overlay");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.className).toContain("bg-red-500/50");
+    expect(overlay?.className).toContain("fixed");
+    expect(overlay?.getAttribute("data-state")).toBe("open");
+  });
+});

--- a/src/components/ui/alert.spec.tsx
+++ b/src/components/ui/alert.spec.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { Alert, AlertDescription, AlertTitle } from "./alert.tsx";
+
+/**
+ * Exercises the real `class-variance-authority` variant lookup and the real
+ * `clsx` + `tailwind-merge` class composition behind `cn`. A regression in any
+ * of those libraries changes the emitted class list and fails these tests.
+ */
+describe("Alert", () => {
+  it("renders as an alert landmark", async () => {
+    const { container } = await render(<Alert>Something happened</Alert>);
+
+    const alert = container.querySelector("[role='alert']");
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toBe("Something happened");
+  });
+
+  it("applies the default variant when none is given", async () => {
+    const { container } = await render(<Alert />);
+
+    const className =
+      container.querySelector("[role='alert']")?.className ?? "";
+    expect(className).toContain("bg-white");
+    expect(className).toContain("text-neutral-950");
+    expect(className).not.toContain("border-red-500/50");
+  });
+
+  it("applies the destructive variant when asked", async () => {
+    const { container } = await render(<Alert variant="destructive" />);
+
+    const className =
+      container.querySelector("[role='alert']")?.className ?? "";
+    expect(className).toContain("border-red-500/50");
+    expect(className).toContain("text-red-500");
+    expect(className).not.toContain("bg-white");
+  });
+
+  it("keeps the shared base classes for every variant", async () => {
+    const { container } = await render(<Alert variant="destructive" />);
+
+    const className =
+      container.querySelector("[role='alert']")?.className ?? "";
+    expect(className).toContain("relative");
+    expect(className).toContain("w-full");
+    expect(className).toContain("rounded-lg");
+  });
+
+  it("merges a caller supplied class instead of duplicating a conflicting one", async () => {
+    const { container } = await render(<Alert className="p-8" />);
+
+    const className =
+      container.querySelector("[role='alert']")?.className ?? "";
+    // tailwind-merge must drop the base `p-4` in favour of the override.
+    expect(className).toContain("p-8");
+    expect(className.split(/\s+/)).not.toContain("p-4");
+  });
+
+  it("forwards arbitrary props to the underlying element", async () => {
+    const { container } = await render(<Alert data-testid="my-alert" id="x" />);
+
+    const alert = container.querySelector("[role='alert']");
+    expect(alert?.getAttribute("data-testid")).toBe("my-alert");
+    expect(alert?.id).toBe("x");
+  });
+
+  it("renders the title as a heading", async () => {
+    const { container } = await render(
+      <Alert>
+        <AlertTitle>Update ready</AlertTitle>
+      </Alert>,
+    );
+
+    const title = container.querySelector("h5");
+    expect(title?.textContent).toBe("Update ready");
+    expect(title?.className).toContain("font-medium");
+  });
+
+  it("renders the description", async () => {
+    const { container } = await render(
+      <Alert>
+        <AlertDescription>Reload to apply it.</AlertDescription>
+      </Alert>,
+    );
+
+    expect(container.querySelector("[role='alert'] > div")?.textContent).toBe(
+      "Reload to apply it.",
+    );
+  });
+
+  it("exposes display names used by React devtools", () => {
+    expect(Alert.displayName).toBe("Alert");
+    expect(AlertTitle.displayName).toBe("AlertTitle");
+    expect(AlertDescription.displayName).toBe("AlertDescription");
+  });
+});

--- a/src/components/ui/button.spec.tsx
+++ b/src/components/ui/button.spec.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { createRef } from "react";
+import { render } from "vitest-browser-react";
+import { Button } from "./button.tsx";
+import { buttonVariants } from "./button-variants.tsx";
+import { cn } from "@/lib/utils.ts";
+import { interact } from "@/test-utils/react.ts";
+
+/**
+ * Exercises the real `class-variance-authority` variants, the real
+ * `tailwind-merge` conflict resolution and the real `@radix-ui/react-slot`
+ * `asChild` behaviour.
+ */
+describe("Button", () => {
+  const button = (container: HTMLElement) => container.querySelector("button");
+
+  it("renders a button element by default", async () => {
+    const { container } = await render(<Button>Click me</Button>);
+
+    expect(button(container)?.tagName).toBe("BUTTON");
+    expect(button(container)?.textContent).toBe("Click me");
+  });
+
+  it("uses the outline/sm defaults declared by the variants", async () => {
+    const { container } = await render(<Button>Default</Button>);
+
+    const className = button(container)?.className ?? "";
+    expect(className).toBe(cn(buttonVariants({})));
+    expect(className).toContain("border");
+    expect(className).toContain("h-9");
+    expect(className).toContain("px-3");
+  });
+
+  it("runs the variant output through tailwind-merge, collapsing duplicates", async () => {
+    // The base classes and the `sm` size both declare `rounded-md`; cva emits
+    // both and tailwind-merge is what collapses them to one.
+    const raw = buttonVariants({});
+    expect(raw.split(/\s+/).filter((c) => c === "rounded-md")).toHaveLength(2);
+
+    const { container } = await render(<Button>Default</Button>);
+
+    const classes = (button(container)?.className ?? "").split(/\s+/);
+    expect(classes.filter((c) => c === "rounded-md")).toHaveLength(1);
+  });
+
+  it.each([
+    ["default", "bg-neutral-900"],
+    ["confirmDanger", "bg-red-600"],
+    ["confirmSafe", "bg-green-900"],
+    ["secondary", "bg-neutral-100"],
+    ["ghost", "hover:bg-neutral-100"],
+    ["link", "underline-offset-4"],
+  ] as const)("applies the %s variant classes", async (variant, expected) => {
+    const { container } = await render(<Button variant={variant}>x</Button>);
+
+    expect(button(container)?.className).toContain(expected);
+  });
+
+  it.each([
+    ["default", "h-10"],
+    ["sm", "h-9"],
+    ["lg", "h-11"],
+    ["icon", "h-10"],
+  ] as const)("applies the %s size classes", async (size, expected) => {
+    const { container } = await render(<Button size={size}>x</Button>);
+
+    expect(button(container)?.className).toContain(expected);
+  });
+
+  it("lets a caller class win over a conflicting variant class", async () => {
+    const { container } = await render(
+      <Button size="sm" className="h-20">
+        x
+      </Button>,
+    );
+
+    const classes = (button(container)?.className ?? "").split(/\s+/);
+    expect(classes).toContain("h-20");
+    expect(classes).not.toContain("h-9");
+  });
+
+  it("renders its child element instead of a button when asChild is set", async () => {
+    const { container } = await render(
+      <Button asChild>
+        <a href="https://example.com">Link button</a>
+      </Button>,
+    );
+
+    expect(button(container)).toBeNull();
+    const anchor = container.querySelector("a");
+    expect(anchor?.getAttribute("href")).toBe("https://example.com");
+    // The variant classes must still be applied to the slotted child.
+    expect(anchor?.className).toContain("inline-flex");
+  });
+
+  it("forwards a ref to the rendered element", async () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    await render(<Button ref={ref}>x</Button>);
+
+    expect(ref.current?.tagName).toBe("BUTTON");
+  });
+
+  it("fires its click handler", async () => {
+    let clicks = 0;
+    const { container } = await render(
+      <Button
+        onClick={() => {
+          clicks++;
+        }}
+      >
+        x
+      </Button>,
+    );
+
+    await interact(() => button(container)?.click());
+
+    expect(clicks).toBe(1);
+  });
+
+  it("does not fire when disabled", async () => {
+    let clicks = 0;
+    const { container } = await render(
+      <Button
+        disabled
+        onClick={() => {
+          clicks++;
+        }}
+      >
+        x
+      </Button>,
+    );
+
+    await interact(() => button(container)?.click());
+
+    expect(clicks).toBe(0);
+    expect(button(container)?.disabled).toBe(true);
+  });
+
+  it("exposes a display name used by React devtools", () => {
+    expect(Button.displayName).toBe("Button");
+  });
+});

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+// Must come before ./main.tsx: it creates the #root element that the entry
+// point mounts into while it is being evaluated.
+import { rootElement } from "./test-utils/create-root-element.ts";
+import "./main.tsx";
+
+/**
+ * Boots the real application entry point. `main.tsx` looks up `#root` and
+ * mounts `<App />` into it through the real `react-dom/client` root API, so a
+ * regression in the entry point or in React's client entry fails here.
+ */
+describe("main entry point", () => {
+  it("mounts the application into #root", async () => {
+    await vi.waitFor(() => {
+      if (!rootElement.querySelector("[data-testid='main-layout-container']")) {
+        throw new Error("app not mounted yet");
+      }
+    });
+
+    expect(
+      rootElement.querySelector("[data-testid='main-header']"),
+    ).not.toBeNull();
+    expect(
+      rootElement.querySelector("[data-testid='main-footer']"),
+    ).not.toBeNull();
+    expect(rootElement.querySelector("textarea")).not.toBeNull();
+  });
+
+  it("mounts inside React's StrictMode wrapper", () => {
+    // StrictMode leaves no DOM of its own, but the tree it wraps must be there.
+    expect(rootElement.children.length).toBeGreaterThan(0);
+  });
+});

--- a/src/save-questions.spec.ts
+++ b/src/save-questions.spec.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { generateFileName, generateMarkdownContent } from "./save-questions.ts";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  generateFileName,
+  generateMarkdownContent,
+  saveFile,
+} from "./save-questions.ts";
 import { Question } from "./stores";
 
 describe("generateFileName", () => {
@@ -247,4 +251,212 @@ Footer with *markdown*.
       expect(result).toBe(expected);
     },
   );
+});
+
+/**
+ * `saveFile` is exercised against the browser's real `Blob`, `URL` and DOM
+ * APIs. Only `window.showSaveFilePicker` is substituted, because the File
+ * System Access picker is a native chooser that cannot be driven unattended;
+ * the substitute is a real object implementing the API's contract, and the
+ * content it receives is asserted on.
+ */
+describe("saveFile", () => {
+  const CONTENT = "# Ask me anything\n\n- [ ] A question?\n";
+  const FILE_NAME = "2023-05-15_ask-me-anything_questions.md";
+
+  // `@types/wicg-file-system-access` declares `showSaveFilePicker` as always
+  // present; this view of `window` makes it optional so the test can install
+  // and remove its own implementation.
+  interface OptionalPicker {
+    showSaveFilePicker?: typeof window.showSaveFilePicker;
+  }
+
+  const testWindow: OptionalPicker = window;
+
+  /**
+   * Chromium really implements `showSaveFilePicker`, and it lives on
+   * `Window.prototype`, so `saveFile`'s `"showSaveFilePicker" in window` check
+   * cannot be defeated by deleting an own property. These helpers find the
+   * property wherever it is defined on the prototype chain, hide it, and put it
+   * back afterwards.
+   */
+  interface PropertyHolder {
+    owner: object;
+    descriptor: PropertyDescriptor;
+  }
+
+  const findPicker = (): PropertyHolder | undefined => {
+    let owner: object | null = window;
+    while (owner) {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        owner,
+        "showSaveFilePicker",
+      );
+      if (descriptor) return { owner, descriptor };
+      owner = Object.getPrototypeOf(owner) as object | null;
+    }
+    return undefined;
+  };
+
+  let hidden: PropertyHolder | undefined;
+
+  const hidePicker = (): void => {
+    hidden = findPicker();
+    if (hidden) {
+      delete (hidden.owner as Record<string, unknown>).showSaveFilePicker;
+    }
+  };
+
+  const restorePicker = (): void => {
+    delete testWindow.showSaveFilePicker;
+    if (hidden) {
+      Object.defineProperty(
+        hidden.owner,
+        "showSaveFilePicker",
+        hidden.descriptor,
+      );
+      hidden = undefined;
+    }
+  };
+
+  afterEach(() => {
+    restorePicker();
+    vi.restoreAllMocks();
+  });
+
+  it("really is backed by a browser that implements the File System Access API", () => {
+    expect("showSaveFilePicker" in window).toBe(true);
+  });
+
+  describe("with the File System Access API available", () => {
+    it("writes the content through the picker's writable stream", async () => {
+      const written: string[] = [];
+      let closed = false;
+      let receivedOptions: SaveFilePickerOptions | undefined;
+
+      testWindow.showSaveFilePicker = (options?: SaveFilePickerOptions) => {
+        receivedOptions = options;
+        return Promise.resolve({
+          createWritable: () =>
+            Promise.resolve({
+              write: (data: string) => {
+                written.push(data);
+                return Promise.resolve();
+              },
+              close: () => {
+                closed = true;
+                return Promise.resolve();
+              },
+            }),
+        } as unknown as FileSystemFileHandle);
+      };
+
+      await saveFile(FILE_NAME, CONTENT);
+
+      expect(written).toEqual([CONTENT]);
+      expect(closed).toBe(true);
+      expect(receivedOptions?.suggestedName).toBe(FILE_NAME);
+      expect(receivedOptions?.types).toEqual([
+        {
+          description: "Markdown Files",
+          accept: { "text/markdown": [".md"] },
+        },
+      ]);
+    });
+
+    it("swallows the abort raised when the user dismisses the picker", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const abort = new DOMException(
+        "The user aborted a request.",
+        "AbortError",
+      );
+      testWindow.showSaveFilePicker = () => Promise.reject(abort);
+
+      await expect(saveFile(FILE_NAME, CONTENT)).resolves.toBeUndefined();
+
+      expect(consoleError).toHaveBeenCalledWith("Error saving file:", abort);
+    });
+
+    it("swallows a failure to open the writable stream", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const failure = new Error("no permission");
+      testWindow.showSaveFilePicker = () =>
+        Promise.resolve({
+          createWritable: () => Promise.reject(failure),
+        } as unknown as FileSystemFileHandle);
+
+      await expect(saveFile(FILE_NAME, CONTENT)).resolves.toBeUndefined();
+
+      expect(consoleError).toHaveBeenCalledWith("Error saving file:", failure);
+    });
+  });
+
+  describe("without the File System Access API", () => {
+    beforeEach(() => {
+      hidePicker();
+      expect("showSaveFilePicker" in window).toBe(false);
+    });
+
+    it("falls back to a download link carrying the content as a markdown blob", async () => {
+      const blobs: Blob[] = [];
+      const created: string[] = [];
+      const revoked: string[] = [];
+      const clicked: HTMLAnchorElement[] = [];
+      const attachedWhileClicked: boolean[] = [];
+
+      const realCreate = URL.createObjectURL.bind(URL);
+      vi.spyOn(URL, "createObjectURL").mockImplementation(
+        (obj: Blob | MediaSource) => {
+          blobs.push(obj as Blob);
+          const url = realCreate(obj);
+          created.push(url);
+          return url;
+        },
+      );
+      const realRevoke = URL.revokeObjectURL.bind(URL);
+      vi.spyOn(URL, "revokeObjectURL").mockImplementation((url: string) => {
+        revoked.push(url);
+        realRevoke(url);
+      });
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+        function (this: HTMLAnchorElement) {
+          clicked.push(this);
+          attachedWhileClicked.push(document.body.contains(this));
+        },
+      );
+
+      await saveFile(FILE_NAME, CONTENT);
+
+      expect(clicked).toHaveLength(1);
+      expect(clicked[0].download).toBe(FILE_NAME);
+      expect(clicked[0].href).toBe(created[0]);
+      // The anchor must be in the document at click time, and gone afterwards.
+      expect(attachedWhileClicked).toEqual([true]);
+      expect(document.body.contains(clicked[0])).toBe(false);
+
+      expect(blobs).toHaveLength(1);
+      expect(blobs[0].type).toBe("text/markdown");
+      expect(await blobs[0].text()).toBe(CONTENT);
+
+      expect(revoked).toEqual(created);
+    });
+
+    it("reports a failure instead of throwing", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const failure = new Error("blob urls unavailable");
+      vi.spyOn(URL, "createObjectURL").mockImplementation(() => {
+        throw failure;
+      });
+
+      await expect(saveFile(FILE_NAME, CONTENT)).resolves.toBeUndefined();
+
+      expect(consoleError).toHaveBeenCalledWith("Error saving file:", failure);
+    });
+  });
 });

--- a/src/stores/layout.spec.ts
+++ b/src/stores/layout.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFooter, useSetFooter, useSetTitle, useTitle } from "./layout.ts";
+import { StorageName } from "./storage-names.ts";
+
+const DEFAULT_TITLE = "Ask me anything";
+const DEFAULT_FOOTER = "François Martin | www.fmartin.ch";
+
+/**
+ * Exercises the real zustand layout store, including the real persist
+ * middleware writing to the browser's real `localStorage`.
+ */
+describe("layout store", () => {
+  const readPersisted = (): unknown =>
+    JSON.parse(localStorage.getItem(StorageName.LAYOUT) ?? "null");
+
+  const renderLayout = () =>
+    renderHook(() => ({
+      title: useTitle(),
+      setTitle: useSetTitle(),
+      footer: useFooter(),
+      setFooter: useSetFooter(),
+    }));
+
+  /**
+   * The store module is shared by every test in this file and rehydrates from
+   * `localStorage`, so each test restores the documented defaults first.
+   */
+  const renderNormalised = () => {
+    const rendered = renderLayout();
+    act(() => {
+      rendered.result.current.setTitle(DEFAULT_TITLE);
+    });
+    act(() => {
+      rendered.result.current.setFooter(DEFAULT_FOOTER);
+    });
+    localStorage.removeItem(StorageName.LAYOUT);
+    return rendered;
+  };
+
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.LAYOUT);
+  });
+
+  it("normalises to the default title and footer", () => {
+    const { result } = renderNormalised();
+
+    expect(result.current.title).toBe(DEFAULT_TITLE);
+    expect(result.current.footer).toBe(DEFAULT_FOOTER);
+  });
+
+  it("updates the title without touching the footer", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setTitle("My Conference Talk");
+    });
+
+    expect(result.current.title).toBe("My Conference Talk");
+    expect(result.current.footer).toBe(DEFAULT_FOOTER);
+  });
+
+  it("updates the footer without touching the title", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setFooter("@example");
+    });
+
+    expect(result.current.footer).toBe("@example");
+    expect(result.current.title).toBe(DEFAULT_TITLE);
+  });
+
+  it("accepts empty strings for both fields", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setTitle("");
+    });
+    act(() => {
+      result.current.setFooter("");
+    });
+
+    expect(result.current.title).toBe("");
+    expect(result.current.footer).toBe("");
+  });
+
+  it("persists title and footer to localStorage through the persist middleware", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setTitle("Persisted title");
+    });
+    act(() => {
+      result.current.setFooter("Persisted footer");
+    });
+
+    expect(readPersisted()).toEqual({
+      state: { title: "Persisted title", footer: "Persisted footer" },
+      version: 0,
+    });
+  });
+
+  it("round-trips unicode through the persisted JSON payload", () => {
+    const { result } = renderNormalised();
+    const unicodeTitle = "Frågor & Antworten - 你好 🎤";
+
+    act(() => {
+      result.current.setTitle(unicodeTitle);
+    });
+
+    const persisted = readPersisted() as { state: { title: string } };
+    expect(persisted.state.title).toBe(unicodeTitle);
+  });
+
+  it("does not persist the action functions, only the serialisable state", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setTitle("anything");
+    });
+
+    const persisted = readPersisted() as { state: Record<string, unknown> };
+    expect(Object.keys(persisted.state).sort()).toEqual(["footer", "title"]);
+  });
+});

--- a/src/stores/onboarding.spec.ts
+++ b/src/stores/onboarding.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useCompleteTour,
+  useRestartTour,
+  useTourCompleted,
+} from "./onboarding.ts";
+import { StorageName } from "./storage-names.ts";
+
+/**
+ * Exercises the real zustand onboarding store, including the real persist
+ * middleware writing to the browser's real `localStorage`.
+ */
+describe("onboarding store", () => {
+  const readPersisted = (): unknown =>
+    JSON.parse(localStorage.getItem(StorageName.ONBOARDING) ?? "null");
+
+  const renderOnboarding = () =>
+    renderHook(() => ({
+      tourCompleted: useTourCompleted(),
+      completeTour: useCompleteTour(),
+      restartTour: useRestartTour(),
+    }));
+
+  /**
+   * The store module is shared by every test in this file and rehydrates from
+   * `localStorage`, so each test restores the pending-tour state first.
+   */
+  const renderNormalised = () => {
+    const rendered = renderOnboarding();
+    act(() => {
+      rendered.result.current.restartTour();
+    });
+    localStorage.removeItem(StorageName.ONBOARDING);
+    return rendered;
+  };
+
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.ONBOARDING);
+  });
+
+  it("derives its initial value from the url, which here does not opt out", () => {
+    // The store's initial value is `href.endsWith("disable-tour")`; the test
+    // runner's url does not, so the tour starts pending.
+    expect(window.location.href.endsWith("disable-tour")).toBe(false);
+
+    const { result } = renderNormalised();
+
+    expect(result.current.tourCompleted).toBe(false);
+  });
+
+  it("marks the tour as completed", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.completeTour();
+    });
+
+    expect(result.current.tourCompleted).toBe(true);
+  });
+
+  it("restarts a completed tour", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.completeTour();
+    });
+    act(() => {
+      result.current.restartTour();
+    });
+
+    expect(result.current.tourCompleted).toBe(false);
+  });
+
+  it("is idempotent when completing twice", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.completeTour();
+    });
+    act(() => {
+      result.current.completeTour();
+    });
+
+    expect(result.current.tourCompleted).toBe(true);
+  });
+
+  it("persists the completion flag to localStorage through the persist middleware", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.completeTour();
+    });
+
+    expect(readPersisted()).toEqual({
+      state: { tourCompleted: true },
+      version: 0,
+    });
+  });
+
+  it("persists the restarted flag as well", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.completeTour();
+    });
+    act(() => {
+      result.current.restartTour();
+    });
+
+    expect(readPersisted()).toEqual({
+      state: { tourCompleted: false },
+      version: 0,
+    });
+  });
+});

--- a/src/stores/preferences.spec.ts
+++ b/src/stores/preferences.spec.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act, type RenderHookResult } from "@testing-library/react";
+import {
+  useDarkMode,
+  useDecreaseFontSize,
+  useFontSize,
+  useIncreaseFontSize,
+  useTimeFormat24h,
+  useToggleDarkMode,
+  useToggleTimeFormat,
+} from "./preferences.ts";
+import { StorageName } from "./storage-names.ts";
+
+const DEFAULT_FONT_SIZE = 34;
+const MIN_FONT_SIZE = 12;
+const FONT_SIZE_STEP = 2;
+
+/**
+ * These tests drive the real zustand store through the real
+ * `devtools(persist(immer(...)))` middleware chain and read back the real
+ * `localStorage` entry that the persist middleware writes. Nothing about
+ * zustand, immer or the browser storage binding is stubbed, so a regression in
+ * any of them fails these tests rather than passing silently.
+ */
+describe("preferences store", () => {
+  const readPersisted = (): unknown =>
+    JSON.parse(localStorage.getItem(StorageName.PREFERENCES) ?? "null");
+
+  const renderPreferences = () =>
+    renderHook(() => ({
+      fontSize: useFontSize(),
+      increaseFontSize: useIncreaseFontSize(),
+      decreaseFontSize: useDecreaseFontSize(),
+      darkMode: useDarkMode(),
+      toggleDarkMode: useToggleDarkMode(),
+      timeFormat24h: useTimeFormat24h(),
+      toggleTimeFormat: useToggleTimeFormat(),
+    }));
+
+  type Preferences = ReturnType<typeof renderPreferences>;
+
+  /**
+   * The store module is shared by every test in this file and additionally
+   * rehydrates from `localStorage`, so each test normalises it back to the
+   * documented defaults through the store's own public API before running.
+   */
+  const normalise = (rendered: Preferences): void => {
+    const { result } = rendered;
+    act(() => {
+      // Clamping means repeated decreases land exactly on MIN_FONT_SIZE
+      // regardless of where the shared store happened to be.
+      for (let i = 0; i < 100; i++) result.current.decreaseFontSize();
+    });
+    act(() => {
+      const stepsBackToDefault =
+        (DEFAULT_FONT_SIZE - MIN_FONT_SIZE) / FONT_SIZE_STEP;
+      for (let i = 0; i < stepsBackToDefault; i++)
+        result.current.increaseFontSize();
+    });
+    if (result.current.darkMode) {
+      act(() => {
+        result.current.toggleDarkMode();
+      });
+    }
+    if (!result.current.timeFormat24h) {
+      act(() => {
+        result.current.toggleTimeFormat();
+      });
+    }
+    localStorage.removeItem(StorageName.PREFERENCES);
+  };
+
+  const renderNormalised = (): Preferences => {
+    const rendered = renderPreferences();
+    normalise(rendered);
+    return rendered;
+  };
+
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.PREFERENCES);
+  });
+
+  it("normalises to the documented defaults", () => {
+    const { result } = renderNormalised();
+
+    expect(result.current.fontSize).toBe(DEFAULT_FONT_SIZE);
+    expect(result.current.darkMode).toBe(false);
+    expect(result.current.timeFormat24h).toBe(true);
+  });
+
+  it("increases the font size in steps of two", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.increaseFontSize();
+    });
+    act(() => {
+      result.current.increaseFontSize();
+    });
+
+    expect(result.current.fontSize).toBe(DEFAULT_FONT_SIZE + 4);
+  });
+
+  it("decreases the font size in steps of two", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.decreaseFontSize();
+    });
+
+    expect(result.current.fontSize).toBe(DEFAULT_FONT_SIZE - 2);
+  });
+
+  it("never lets the font size drop below the 12px floor", () => {
+    const { result } = renderNormalised();
+
+    // 34 -> 12 takes 11 steps; run 20 to push well past the floor.
+    act(() => {
+      for (let i = 0; i < 20; i++) result.current.decreaseFontSize();
+    });
+
+    expect(result.current.fontSize).toBe(MIN_FONT_SIZE);
+  });
+
+  it("increases again from the floor", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      for (let i = 0; i < 20; i++) result.current.decreaseFontSize();
+    });
+    act(() => {
+      result.current.increaseFontSize();
+    });
+
+    expect(result.current.fontSize).toBe(MIN_FONT_SIZE + 2);
+  });
+
+  it("toggles dark mode back and forth", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+    expect(result.current.darkMode).toBe(true);
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+    expect(result.current.darkMode).toBe(false);
+  });
+
+  it("toggles the time format back and forth", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.toggleTimeFormat();
+    });
+    expect(result.current.timeFormat24h).toBe(false);
+
+    act(() => {
+      result.current.toggleTimeFormat();
+    });
+    expect(result.current.timeFormat24h).toBe(true);
+  });
+
+  it("keeps the other preferences untouched when one changes", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.fontSize).toBe(DEFAULT_FONT_SIZE);
+    expect(result.current.timeFormat24h).toBe(true);
+  });
+
+  it("persists every preference to localStorage through the persist middleware", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.increaseFontSize();
+    });
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+    act(() => {
+      result.current.toggleTimeFormat();
+    });
+
+    expect(readPersisted()).toEqual({
+      state: {
+        fontSize: DEFAULT_FONT_SIZE + 2,
+        darkMode: true,
+        timeFormat24h: false,
+      },
+      version: 0,
+    });
+  });
+
+  it("does not persist the action functions, only the serialisable state", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.increaseFontSize();
+    });
+
+    const persisted = readPersisted() as { state: Record<string, unknown> };
+    expect(Object.keys(persisted.state).sort()).toEqual([
+      "darkMode",
+      "fontSize",
+      "timeFormat24h",
+    ]);
+  });
+
+  it("re-renders subscribers when the value they select changes", () => {
+    let fontSizeRenders = 0;
+    const fontSizeHook: RenderHookResult<number, void> = renderHook(() => {
+      fontSizeRenders++;
+      return useFontSize();
+    });
+    const controls = renderNormalised();
+
+    const rendersBefore = fontSizeRenders;
+    act(() => {
+      controls.result.current.increaseFontSize();
+    });
+
+    expect(fontSizeRenders).toBeGreaterThan(rendersBefore);
+    expect(fontSizeHook.result.current).toBe(controls.result.current.fontSize);
+  });
+});

--- a/src/stores/qr-code.spec.ts
+++ b/src/stores/qr-code.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useQrCodeSize,
+  useQrCodeUrl,
+  useSetQrCodeSize,
+  useSetQrCodeUrl,
+} from "./qr-code.ts";
+import { StorageName } from "./storage-names.ts";
+
+const DEFAULT_QR_CODE_SIZE = 100;
+
+/**
+ * Exercises the real zustand QR code store, including the real persist
+ * middleware writing to the browser's real `localStorage`.
+ */
+describe("qr code store", () => {
+  const readPersisted = (): unknown =>
+    JSON.parse(localStorage.getItem(StorageName.QR_CODE) ?? "null");
+
+  const renderQrCode = () =>
+    renderHook(() => ({
+      url: useQrCodeUrl(),
+      setUrl: useSetQrCodeUrl(),
+      size: useQrCodeSize(),
+      setSize: useSetQrCodeSize(),
+    }));
+
+  /**
+   * The store module is shared by every test in this file and rehydrates from
+   * `localStorage`, so each test restores the documented defaults first.
+   */
+  const renderNormalised = () => {
+    const rendered = renderQrCode();
+    act(() => {
+      rendered.result.current.setUrl("");
+    });
+    act(() => {
+      rendered.result.current.setSize(DEFAULT_QR_CODE_SIZE);
+    });
+    localStorage.removeItem(StorageName.QR_CODE);
+    return rendered;
+  };
+
+  beforeEach(() => {
+    localStorage.removeItem(StorageName.QR_CODE);
+  });
+
+  it("normalises to an empty url and the default size", () => {
+    const { result } = renderNormalised();
+
+    expect(result.current.url).toBe("");
+    expect(result.current.size).toBe(DEFAULT_QR_CODE_SIZE);
+  });
+
+  it("stores the url that was set", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setUrl("https://example.com/talk");
+    });
+
+    expect(result.current.url).toBe("https://example.com/talk");
+  });
+
+  it("clears the url when set back to an empty string", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setUrl("https://example.com/talk");
+    });
+    act(() => {
+      result.current.setUrl("");
+    });
+
+    expect(result.current.url).toBe("");
+  });
+
+  it("stores the size verbatim: clamping is the component's job, not the store's", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setSize(1000);
+    });
+
+    expect(result.current.size).toBe(1000);
+  });
+
+  it("changing the size leaves the url alone", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setUrl("https://example.com/talk");
+    });
+    act(() => {
+      result.current.setSize(128);
+    });
+
+    expect(result.current.url).toBe("https://example.com/talk");
+    expect(result.current.size).toBe(128);
+  });
+
+  it("persists url and size to localStorage through the persist middleware", () => {
+    const { result } = renderNormalised();
+
+    act(() => {
+      result.current.setUrl("https://example.com/qr");
+    });
+    act(() => {
+      result.current.setSize(128);
+    });
+
+    expect(readPersisted()).toEqual({
+      state: { qrCodeUrl: "https://example.com/qr", qrCodeSize: 128 },
+      version: 0,
+    });
+  });
+});

--- a/src/test-utils/create-root-element.ts
+++ b/src/test-utils/create-root-element.ts
@@ -1,0 +1,11 @@
+/**
+ * Test-only side effect: creates the `<div id="root">` that `src/main.tsx`
+ * mounts into.
+ *
+ * `main.tsx` runs its mount at module evaluation time, so the element has to
+ * exist before that module is imported. ES module imports are evaluated in
+ * source order, so importing this module above `main.tsx` guarantees it.
+ */
+export const rootElement = document.createElement("div");
+rootElement.id = "root";
+document.body.appendChild(rootElement);

--- a/src/test-utils/keyboard.ts
+++ b/src/test-utils/keyboard.ts
@@ -1,0 +1,60 @@
+/**
+ * Test-only helpers for driving real keyboard events.
+ *
+ * `react-hotkeys-hook` listens for `keydown`/`keyup` on `document` and matches
+ * on `KeyboardEvent.code` (falling back to `.key`), so these helpers dispatch
+ * genuine `KeyboardEvent`s carrying both. Nothing about the hotkey library is
+ * stubbed: a regression in its matching, its modifier handling or its
+ * "fire once per physical press" guard shows up as a failing test.
+ *
+ * The trailing `keyup` matters — the library latches a hotkey after `keydown`
+ * and only re-arms it on `keyup`.
+ */
+export interface KeyPress {
+  /** `KeyboardEvent.key`, e.g. `"t"`, `"Enter"`, `"ArrowUp"`. */
+  key: string;
+  /** `KeyboardEvent.code`, e.g. `"KeyT"`, `"Enter"`, `"ArrowUp"`. */
+  code: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  meta?: boolean;
+  /** Defaults to `document`, which is where `useHotkeys` binds. */
+  target?: EventTarget;
+}
+
+const toEventInit = (press: KeyPress): KeyboardEventInit => ({
+  key: press.key,
+  code: press.code,
+  ctrlKey: press.ctrl ?? false,
+  shiftKey: press.shift ?? false,
+  altKey: press.alt ?? false,
+  metaKey: press.meta ?? false,
+  bubbles: true,
+  cancelable: true,
+});
+
+/** Dispatches a full keydown + keyup cycle. */
+export function pressKey(press: KeyPress): void {
+  const target = press.target ?? document;
+  const init = toEventInit(press);
+  target.dispatchEvent(new KeyboardEvent("keydown", init));
+  target.dispatchEvent(new KeyboardEvent("keyup", init));
+}
+
+/**
+ * Dispatches only the keydown half, for assertions about `preventDefault`
+ * or about handlers that inspect the event itself.
+ */
+export function keyDown(press: KeyPress): KeyboardEvent {
+  const target = press.target ?? document;
+  const event = new KeyboardEvent("keydown", toEventInit(press));
+  target.dispatchEvent(event);
+  return event;
+}
+
+/** Releases a key previously sent with {@link keyDown}. */
+export function keyUp(press: KeyPress): void {
+  const target = press.target ?? document;
+  target.dispatchEvent(new KeyboardEvent("keyup", toEventInit(press)));
+}

--- a/src/test-utils/react.ts
+++ b/src/test-utils/react.ts
@@ -1,0 +1,18 @@
+import { act } from "@testing-library/react";
+
+/**
+ * Test-only helper: runs a real user interaction and lets React flush the
+ * resulting render and effects before the assertions run.
+ *
+ * The components under test update zustand stores from DOM event handlers, and
+ * React 19 schedules the resulting render asynchronously, so assertions made
+ * immediately after `element.click()` would read stale DOM.
+ */
+export async function interact(
+  action: () => void | Promise<void>,
+): Promise<void> {
+  await act(async () => {
+    await action();
+    await Promise.resolve();
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,19 @@ export default defineConfig({
     coverage: {
       provider: "istanbul",
       reporter: ["text", "html", "lcov"],
+      // Without an explicit include, only files that a test happens to import
+      // are counted, which silently hides every untested file from the report.
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        // Test code, not shipped application code.
+        "src/**/*.spec.{ts,tsx}",
+        "src/__mocks__/**",
+        "src/test-utils/**",
+        "src/vite-env.d.ts",
+      ],
+      thresholds: {
+        lines: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Problem

The reported coverage was misleading. `vitest.config.ts` set no `coverage.include`, so only modules actually imported by the three spec files were instrumented. The headline **74.92%** was computed over **10 of 39 source files**; `App.tsx`, `HelpModal.tsx`, `QuestionList.tsx` and nearly all of `components/ui` were simply absent from the report.

Measured honestly over all of `src`, the real starting point was **~38%**.

No threshold was configured either, so coverage was printed and discarded and could not fail CI at all.

## Change

- Measure coverage over all of `src`, so the number stops hiding anything.
- Raise coverage to **90.53% lines** (622/687), 89.75% statements, 90.94% functions, 71.11% branches, across 24 test files and 246 tests.
- Enforce an 80% line threshold that actually fails the build.

## Verification

`bun run test:unit` (the exact CI command) on a fresh clone:

```
Test Files  24 passed (24)
     Tests  246 passed (246)
Statements : 89.75% ( 683/761 )
Branches   : 71.11% ( 197/277 )
Functions  : 90.94% ( 231/254 )
Lines      : 90.53% ( 622/687 )
```

Run 7 times, including once after clearing the vite and vitest caches. Six runs gave 90.53%; one gave 90.82% (a genuine 2-line timing-dependent variance, disclosed rather than smoothed over). Best apples-to-apples comparison against the same denominator: **38.28% → 90.53%**.

The gate was proven to fail three ways:

| Mutation | Result |
|---|---|
| Threshold raised to 95% | `does not meet global threshold (95%)`, exit 1 |
| The new spec files removed, literal CI command | 40.28%, exit 1 |
| **A new module with 100 untested exported functions added** | below threshold, exit 1 |

No existing test was deleted and no assertion weakened.

## A pre-existing bug found and deliberately not fixed

`setup-vitest.ts` calls `vi.mock("zustand")` intending to load `src/__mocks__/zustand.ts`, but vitest resolves `__mocks__` for node_modules packages **relative to the project root**, not under `src/`. Proven: `create.toString()` inside a test returns vitest's generic autospy wrapper, and the mock's `console.log("zustand create mock")` never fires.

Consequences: `src/__mocks__/zustand.ts` (62 lines) is dead code, and its `afterEach` store reset never registers, so store state leaks between tests within a file and across files via real localStorage.

The likely fix is a one-line directory move to the repository root, but that changes shared test infrastructure and could alter existing test outcomes, so it is left as a maintainer decision. The new tests work around it by normalising store state through each store's own public API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad browser and integration coverage across the application, including keyboard shortcuts, dialogs, onboarding, QR codes, stores, persistence, accessibility, and file export.
  * Added tests for the application entry point and shared UI components.
* **Quality**
  * Coverage now includes source TypeScript files and enforces a minimum of 80% line coverage.
  * Added clearer coverage enforcement messaging and support for test failure screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->