### PR TITLE
fix(test): make the zustand manual mock actually load

### DIFF
--- a/__mocks__/zustand.ts
+++ b/__mocks__/zustand.ts
@@ -23,8 +23,6 @@ const createUncurried = <T>(
 export const create = (<T>(
   stateCreator: ZustandExportedTypes.StateCreator<T>,
 ) => {
-  console.log("zustand create mock");
-
   // to support curried version of create
   return typeof stateCreator === "function"
     ? createUncurried(stateCreator)
@@ -46,8 +44,6 @@ const createStoreUncurried = <T>(
 export const createStore = (<T>(
   stateCreator: ZustandExportedTypes.StateCreator<T>,
 ) => {
-  console.log("zustand createStore mock");
-
   // to support curried version of createStore
   return typeof stateCreator === "function"
     ? createStoreUncurried(stateCreator)

--- a/setup-vitest.ts
+++ b/setup-vitest.ts
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, vi } from "vitest";
 
-vi.mock("zustand"); // to make it work like Jest (auto-mocking)
+// Loads the manual mock in `__mocks__/zustand.ts`, which wraps zustand's
+// `create`/`createStore` so every store registers a reset function that runs
+// after each test. For node_modules packages vitest only looks for `__mocks__`
+// directly under the project root, so that folder must NOT be moved under
+// `src/`. If it is, this call silently falls back to vitest's auto-mock and the
+// reset never registers, so store state leaks between tests.
+vi.mock("zustand");
 
 // Mocks the textarea's scrollHeight to a fixed value to ensure consistent height calculations
 // across different test environments and runs to make snapshot tests deterministic.

--- a/src/stores/zustand-mock.spec.ts
+++ b/src/stores/zustand-mock.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { create } from "zustand";
+
+/**
+ * Guards the wiring that isolates store state between tests.
+ *
+ * `setup-vitest.ts` calls `vi.mock("zustand")`, which only picks up the manual
+ * mock in `__mocks__/zustand.ts` when that folder sits at the project root:
+ * for `node_modules` packages vitest resolves `__mocks__` relative to the root,
+ * never relative to `src/`. If the folder is moved, vitest silently falls back
+ * to auto-mocking, the mock's `afterEach` reset never registers, and every
+ * store carries its state into the following test.
+ *
+ * These tests deliberately run in order: the second one mutates a store and the
+ * third one asserts the mock reset it.
+ */
+
+interface CounterState {
+  count: number;
+  increment: () => void;
+}
+
+const useCounterStore = create<CounterState>()((set) => ({
+  count: 0,
+  increment: () => {
+    set((state) => ({ count: state.count + 1 }));
+  },
+}));
+
+describe("zustand manual mock", () => {
+  it("starts from the store's initial state", () => {
+    expect(useCounterStore.getState().count).toBe(0);
+  });
+
+  it("keeps a mutation visible within the test that made it", () => {
+    useCounterStore.getState().increment();
+    expect(useCounterStore.getState().count).toBe(1);
+  });
+
+  it("resets every store after each test, so the mutation does not leak", () => {
+    expect(useCounterStore.getState().count).toBe(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "e2e", "playwright.config.ts"],
+  "include": ["src", "e2e", "__mocks__", "playwright.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
       exclude: [
         // Test code, not shipped application code.
         "src/**/*.spec.{ts,tsx}",
-        "src/__mocks__/**",
         "src/test-utils/**",
         "src/vite-env.d.ts",
       ],


### PR DESCRIPTION
Found while raising coverage in #904.

## The problem

`setup-vitest.ts` calls `vi.mock("zustand")` intending to load `src/__mocks__/zustand.ts`, but vitest resolves `__mocks__` for node_modules packages **relative to the project root**, not under `src/`.

Confirmed before changing anything, with a throwaway probe asserting `create.toString()`:

```
+ function(...args) {
+     registerCalls(args, state, prototypeState);
+     registerInvocationOrder(invocationCallCounter++, state, prototypeState);
...
```

That is vitest's generic autospy wrapper, not the repository's mock. So `src/__mocks__/zustand.ts` (62 lines) was dead code and its `afterEach` store reset never registered.

## Honest result

I expected activating the mock to expose tests that only passed because state leaked between them. **It did not: 0 newly failing tests, across 5 repeated full-suite runs.** Two measured reasons: the existing specs already normalise shared store state per test, and vitest 4's auto-mock falls through to the real implementation.

So nothing needed repairing, and nothing was weakened or deleted. The fix is still worth keeping: the reset is now genuinely wired up, proven by a before/after counterfactual, so it protects tests written from here on rather than repairing existing ones.

Coverage still meets the 80% gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for state initialization, updates, and automatic resets between tests.
  * Expanded TypeScript and coverage configuration to include mock implementations.

* **Chores**
  * Removed debug logging from test mocks.
  * Improved documentation for mock resolution and state reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->